### PR TITLE
AbundanceMatching class updates

### DIFF
--- a/SHAM_test.ipynb
+++ b/SHAM_test.ipynb
@@ -18,7 +18,7 @@
    "version": "2.7.11"
   },
   "name": "",
-  "signature": "sha256:1583482f38e9054f21b23023732de693573ce31847e1c52bf036b7d45dace021"
+  "signature": "sha256:3dd83d15b4e5b6befbacbae64d959a86e9d383af47ac7ec0034342035bf81110"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -182,6 +182,26 @@
       }
      ],
      "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "SHAM_model.param_dict"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 8,
+       "text": [
+        "{u'scatter_model_param1': 0.0}"
+       ]
+      }
+     ],
+     "prompt_number": 8
     },
     {
      "cell_type": "code",

--- a/SHAM_test.ipynb
+++ b/SHAM_test.ipynb
@@ -1,212 +1,4 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from halotools.empirical_models import abundance_matching\n",
-    "from halotools import sim_manager\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline  "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "#load halo catalogue\n",
-    "default_halocat = sim_manager.CachedHaloCatalog() \n",
-    "halo_table = default_halocat.halo_table"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "#define schecter function\n",
-    "class Log_Schechter():\n",
-    "    \n",
-    "    def __init__(self, phi0, x0, alpha):\n",
-    "        self.phi0 = phi0\n",
-    "        self.x0 = x0\n",
-    "        self.alpha = alpha\n",
-    "    \n",
-    "    def __call__(self, x):\n",
-    "        x = np.asarray(x)\n",
-    "        x = x.astype(float)\n",
-    "        norm = np.log(10.0)*self.phi0\n",
-    "        val = norm*(10.0**((x-self.x0)*(1.0+self.alpha)))*np.exp(-10.0**(x-self.x0))\n",
-    "        return val\n",
-    "\n",
-    "#define galaxy abundance function\n",
-    "dn_gal = Log_Schechter(10**(-3),10.5,-1.4)\n",
-    "\n",
-    "#get tabulated form\n",
-    "mstar = np.linspace(8,12,100)\n",
-    "dn = dn_gal(mstar)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(100,) (100,)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "//anaconda/lib/python2.7/site-packages/scipy/optimize/minpack.py:604: OptimizeWarning: Covariance of the parameters could not be estimated\n",
-      "  category=OptimizeWarning)\n",
-      "halotools/empirical_models/abundance_matching/abundance.py:220: RuntimeWarning: overflow encountered in exp\n",
-      "  return -1.0*np.exp(a*x+b) + c*x + d\n"
-     ]
-    }
-   ],
-   "source": [
-    "params = {'n': dn, 'x': mstar, 'type': 'differential'}\n",
-    "ab_func = abundance_matching.AbundanceFunctionFromTabulated(**params)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAGldJREFUeJzt3X2UVPV9x/H3DyI+oLs8+DwxyoKxNaZxBVI1qVUXQp0r\nloqKBpOcKIwxSZOmjUbTnoBNeoLGPLU9DQwkbRLJSRRJLM4qLGzjQ4gGFU41PTGBBYyjIvK0MYhP\nfPvHvcMOyz7MzM7MvXPv53XOHmZ+zux879n1fvf+7r2/jzMzREQkeYaFXYCIiIRDDUBEJKHUAERE\nEkoNQEQkodQAREQSSg1ARCSh3hF2AX1xzunaVBGRCpiZK/W1kWwAAOm70uRm5wDwlnq0b2z3xyf0\njOe782RWZADITs+SakpVNF5vzjnifP+Ftq+xxXn74rxt4G9fOeo6BeScG+eca3POfd45N26o3y+z\nIkP7xnbaN7Yf2LFXMp7vzuMt9fCWeuS784OOi4jEQUUNwDm3oNfzmcGOfe4gb20F1gFrgJkDvTA7\nPXvQ4/SENOkJ6YPGq6XWDUONRESiqOwpoGAnPxO4JXjeCpiZrXHOtTjnzjazDX2918yWB++ZAtwz\n0OcUT8+kmlIHpn2KZadnD5rSqXS8XIXGUHhcqK2U8Tn3HdxIek9JRX36SkTio+wGYGaLnXNXFA3N\nAlYFj7uAKcAG59xMwAAX/LvazLqdc21Ah5ltGVLl9N8Yyh2vdcMo9tJLMGzYPI48EuyaDK+f6jeG\n1i9lmLo9xy9OzbD1cH/sku9kmH96jtGj4Uu/yfDoy/743BUZ2is8D1IP8+bNq9tnhUHb17jivG2V\ncJWcEHHOrTKzDwWPFwILzWxDsHOfYma39vO+NuBm/EbRUTgi6ON1FuUTNUM9+XzyMSleew2m/9ij\n8/f+Tn1SU5rPHJtjwe89/u9Nfyy1N82kZ3Ps3g1P/YnHH07yx/ldmtHtfmN4ZZpH9wn++Cmvpbl6\nvz++FI9fv+GPn39cmv+ammPUKNg7PM8nH2i8E+ciMrjgJHfJZ4Lr2gDK+P6RbgDVUukU0H9ckuVo\nS7FrF3xslcfa7f6O/qwRaa4dlmPXLvgRHr8/0h9v2pbm2JV+I9l5iQen++PHvJjmnN/4DeOJd3s8\nf5Q/fuZhaf7xtBxjxsCXN3msfSU4Ihmfpv3a6B55iCRdvRrASjObFjz+Kv5f853BtM84M7uz7G96\n8PdPRAOohnJ3xOmlHg8E5yM+cHyafz7Dbxi3bfR4ep8//q59ac7b7I8/Pt5jzwk9Rx5H3+c3jN3p\nniOSd76W5prgyONHeDzzRs/3v+uSHGPHwp79eW64X0ceIrUUxhFAKzDRzJY4527CbwZ9ngQu4/sf\nUtS8efOYP3/+UL6tMLTpq4VelibnH3lc+4DHL4JzEmcdnuZal2PHDvjxsJ4jj2NeTDOqPcfOnfDH\nGT1HHqNeTvOBrX5jeOQUj82HBedBRqa542x//B+e8vif50u790PNQpJo/vz53HbbbYeM17QBBH/l\nZ4EvmNmSYGwOsBn/r/8lZX3Dvj9DRwARV24jueQujwc3+Tv0c8emueUU/wjj9uc9fvO2P35id5o/\nXe83kt9O8tj3Ln/88OfSnPFEjmOPhf9r9XjpmJ6pqn8al+NbL3v8arc/9lctaR74iKapJJnqcgRQ\na2oA8VPpkcfbb8OX35/lsH0pXnkFbtrgseGP/s7+1NfT/PmmHKtP8Ng5tmeaqmlFjuOP90+Q7z7O\nHx+/P81nj81xwgnwzW0ej+0s/c5ykUahBiCxNtgU0KJLs4zcn2L7dvjYyp4d/emkmfpyjm3boPNE\nj11BY3Ab05z6aI6TToKu8zy2Nfnjf3ZEmjvPyZFKgWvK8/mHdCQh0acGIBIo5ajjW21Zhu9N8eKL\n8LePeax/NbgE949pzngyRz4Pv3u/x/7x/vixu9L89as53vUuuPdwj//dV/oVUiK1pgYgUqH+dtzF\nixFOak4z96gczz0H//mGxwsjDz6SaGmB303uORH+wRPSrPxojqOOUmOQ2lMDEKmyUo4k/n1alrd3\np9i0yb+CqXAT3tEvpHnrB/45iT/O8NgxpudEePts/9JZNQapFjUAkZD13qGfODLF1q0w6789ntjT\ncyns2z/M0dQEb1zhsX20P37hyWk65+RwTo1ByqcGIBJRfS0JsmULXPlTjyf/4DeAI55Lc+RPc0yc\nCJvP99g07NCrlUT6owYg0mB6N4Z3vJZi3Tr43BMeG53fAEa+kObDluPCC+GMSXm+tE5HBnKohmgA\nzrmFZvaJAf67GoAkXqExmMFnW7L8Zl2Khx6C+5s83hzXc1L64RtyHHmkpoykfktBLDCzW4qezwR2\nAy1mtniQ97YCGTO7cYDXqAGI9CN9l8cDwV3Vo19J89b3/SODLR/oWc9JU0bJVG4DKDsRrCgQpvD8\nQCBM8PzsAd47Dr9R7C73c0XEt/iynoS8p/8ly9atcPXVsH17z2ueew527AivRmkM1VgNdAGwKlgN\ntA1oNbM7+wqEASYBu4BbgZv7C4XREYBI+fLdea6/L8P2l+Hkp7I8fH+Kiy6Cy2bnWfZ6Buc0NRR3\n5R4BlJ0IVvicosejgJ1Fz8cCmNm9fbyv0znXDDRX+Lki0o9UU4oHP9Iz7bNnD9x7L/zDQ5kDayJ9\n9J4Ma67X1JD4KgqFHwoz22Nm06oRCSki/Wtuhuuug/PP6xl75BG48kpY8fM83lIPb6lHvjsfXpES\nqkqPAIrnZ3YBY4LHowDNPIpESHG29TfmZlm5DK66K8O+U/yjgsyKjE4YJ1Q1poDuBiYCnUAL0DHU\nokSkelJNqYN28Gd8Bh68Cx7Y5D9fuxbWnAhtbSEVKKGp5CqgmcDEIAQGM1sfjLcBu4aaBlb0OQd9\nKQ1MpHoKVxJdMj7NV/48yw03wLRpsOqXmhpqFPPnzz9kP1ku3QksIrz5JixeDJ9b5/HGabqXoFHV\n/D4AEYmfww6DT34S/vLCnrHnnwf9HRZvOgIQkQMKy0ns6YY9d2U5/ogU3/0unHZa2JVJKRpiLaDB\nqAGIhO+tt+Cb34Q77oDbb4ePfxwqmGaWOlIDEJGqevppuGpOnt1/keG974X//BvdTRxVagAiUnWX\n/NDjwS7/5PAHjk/z6I06ORxFOgksIlU3rGhP8atfwY9/HF4tUj06AhCRQRVnDXy2JUvmmhSzZ8NX\nvqLzAlGiKSARqbnt2+Gyy+D002HJEhgxIuyKBBpgCsg5N9c5d/FAuQEiEm3HHQdr1sBLe/OcfJPH\ntB/ozuFGVFEDCDIAip/PdM61BWExA71vLtBhZp3VWjJCRMJx1FHwjhkZdoxpZ9Xmdq77WSbskqRM\ndU0Ew1807pygYbSW+9kiEi3F8/+PPw67lfXXUMpeDdTMFjvnrigamgWsCh53AVOADX0kgq3BXzp6\nNX5oTAZYX3npIhK24qWmj9+ZJZ2GVavg6KNDLkxKUmkk5Coz+1DweCGw0Mw2BCuCTjGzW/t5XxMw\nFb8hPKVISJH42L8f5s6FrVvh/vvhiCPCrih5In0S2My6zexeM1uuRDCReBk2DLJZGDMGrr3WbwgS\nbZU2ACWCicghhg+HH/4QntudZ8I85QpEXaUNoHciWEvwuAV/jn/IFAgj0pgOPxyar82w+R3ttG9s\nP3COQKqrGoEwkU0EM7ODvtQARBrHiMN6Hu/cGV4dcTZ//vxD9pPl0p3AIlJ1haUjtr8CW/4ty1M/\nT/HOd4ZdVfxpKQgRiZQFC+BnP4OHH9aSEbWmBiAikWIGM2bAu98NX/ta2NXEmxqAiETOjh1w9tn+\nwnHTpoVdTXxF+j4AEUmmsWP9y0M//nHYti3saqRADUBE6uLCC+FvPpbnfbfr/oCoUAMQkbrpOjPD\ntmbdHxAVagAiUjfF0ZKvvxFeHeJTAxCRuslOz5KekKblrTQjO7Nhl5N4db0KyDnXjL9cxGigS6uB\niiTT3r1w5pnw3e9CW1vY1cRHXa4CqjQRDJiEnxewC3/hOBFJoKOOgm9/Gz71KXhDU0GhqXci2BPA\neCCLHx4jIgl12WUwYQJ8/ethV5JclQbCrDSzacHjBcAqM+sMFoRrNbM7+0kEuypIFGsGMmbW532B\nmgISSYauLpg8GZ55Bk46KexqGl+5U0BlR0IWPqfo8SigeL2/sQBmdm8fxW1yzl2MPwXUUeFni0hM\ntLTAddfBvHl+mIzUV6UNoCJm1lnPzxOR6PviF+GMM+Azn4Gzzgq7mmRRIpiIhGr0aPjULXkuWqI7\nhOtNiWAiErrHjs/wymjdIVwOJYKJSCwMK3/flXhKBBORWMh355n73xkeehi+NyPLrHQq7JIakvIA\nRKRhLV0K3/kOPPIIVDCjkXjKAxCRhnX11X54zOqqnEmUwagBiEhkDB8Ot9wCt98ediXJoAYgIpFy\nzTXw29/Ck0+GXUn8qQGISKSMGAGf+xzccUfYlcSfTgKLSOT84Q/+MhGPPQbjx4ddTePQSWARaXjH\nHAM33ADf+EbYlcSbjgBEJJJeeMFfG2jzZmhuDruaxhC5IwDn3LjgLmGcc81BcMzlwZLQIiJ9Ovlk\nmDoVvv/9sCuJr5IawBASwACuAAo7+1uD4Jg1gBb8EJEBXT03z63PeKS1SFxNDNoAhpgABgcvDjcK\n/8176FlATkSkT0u2ZdibaucBLRJXE4PmAQQJXlcUDc0CVgWPu/Azfjf0kQC22sy6e327Xc65puA1\nm4ZavIiIVK7UQJiKEsACU4AxzrnVwCJgKn6DUP6PiAwoOz3L9T/LsKYTbrtau4xqq3kiWK/c325g\nS60/U0TiIdWU4sGP5vjEWli5DCb9Y9gVxUupVwEpAUxEQnP99fC978H+/WFXEi+lNoCaJ4Ad8oFK\nBBORwKRJMHIk/PznYVcSHdVIBBv0RrDg5G4W+IKZLQnG5gCbgXGFsWrSjWAi0tu//is8/rifGSB9\nUyCMiMTSjh3+ukBbtsCoUWFXE02RuxNYRKQaxo6Fiy+G5cvDriQ+1ABEpGHMng0/+lHYVcSHpoBE\npGHs2+evEfTMM/6/cjBNAYlIbB1xBMyYAT/5SdiVxIMagIg0lA9/WNNA1aIGICIN5aKL4Pnn4dln\nw66k8akBiEhDGT4crrwSli0Lu5LGpwYgIg3nAi/PHc97eMoJGJJ6J4KNC4JkPu+cG1frzxaRePre\n9gzdJ7bTrpyAIal3IlgrsA4/EWxmv+8QERlABcveSB/qkQjWUXhgZsuDkJgpgGbwRKQi2elZJo9K\nM+rlNNnpygmoVD0SwRxFq4kG00EdZralKlsgIomTakrx6I05TjwR+CLQFHZFjameiWAdwGTgZqDL\nOddhZlrVQ0QqMmIEXHop/PSn8OlPh11NY6p3Itia4EtEZMhmzIBFi9QAKqVEMBFpWFOnwtq18Oqr\nYVfSmJQIJiIN65hj4NxzYXVN9kLRpkQwEUm8b38bnn4allR9T9R4lAgmIomycSNccIG/PtCwhK9t\noOWgRSRRJkzwp4LWrw+7ksajBiAiDe/SSyGXC7uKxqMGICINz/Pg/vvDrqLx6ByAiDS811+H446D\nLVtgzJhBXx5bOgcgIolz+OHwwQ9CZ2fYlTQWNQARiYUpU5J5P8BQqAGISCxMnQodHYO/TnqoAYhI\nLJx1FuzdC11dYVfSOOqaCFY0trDWnysiyeKcPw2ko4DS1TsR7ECgTFlVioiUQOcBylOPRLADP44g\nB3h38CUiUlXvOTfPfSM90ncpLL4UgzYAM1uMn/xVMIueHXghEaxwVHB50b/FGT2F61LH4S8hPd45\nd9oQaxcROci8JzK8Oa6dBzYpLL4UdU0EM7NO51wzRVNCIiISjnongmFme4Bptf5cEUme7PQsly7K\n8OKLKCy+BKU2ACWCiUjkpZpS3P/hHO97H5x0Z9jVRJ8SwUQkVlIpGDUKfv3rsCupLSWCiYj04frr\nobU1eWHxSgQTkcT7wQ/85aHvvjvsSupLDUBEEm/rVnj/++Gll/w7hJNCy0GLSOKdeioceSQ8+2zY\nlUSbGoCIxNIFF8Ajj4RdRbSpAYhILJ13Hvzyl2FXEW1qACISS+efrwYwGJ0EFpFYevttGD06WTnB\nOgksIgIMHw6TJ8Njj4VdSXSpAYhIbJ1/PqxdG3YV0VX3RDDn3Fzn3MUl5AiIiAyJTgQPrK6JYMHr\nO8ys08w2lF2tiEgZzj0X1q2Dt94Ku5JoqmsiGDAROCdoIK0V1CsiUrIxY/zF4Z55JuxKoqleiWAF\nu/AbwlPAVUOqXESkBJoG6l89E8FWA18FpuLnCywqr1QRkfKddx48+ijceGPYlURP3RPBgP4ahYhI\n1U2eDN/6VthVRFOpVwEpEUxEGtJ73uPfDPbqq2FXEj1KBBORWDvsMHjve2H9+rArqS4lgomIlODT\nn4aWFvj7vw+7ktoqdymIQc8BBCd37+01VvWdvohIrUyeDCtXhl1F9GgpCBGJvVPOzHPf0R7eUo98\ndz7sciJDDUBEYu/OZzPsTbXTvrGdzIpM2OVEhhqAiMReknKBy6E8ABGJvXx3nr+4I8OIEbDm77Kk\nmlJhl1QTVT8JLCLS6FJNKb5yZo7lyyHV1yI1CaUpIBFJhMmTYd++sKuIFk0BiYjEROSmgJxz44AW\nM1vjnGvGv3t4NNBlZltq/fkiItK3ugbCAJPwVwfdhb+OkIiIhKQegTAdRY+fAMbjLy3R1ffLRUSk\nHuoRCFM8H3WVmX0ieM8NQ65eREQqVu9AmE3OuYvxp4A6+nm9iIjUQb0DYTpr/XkiIlIaBcKIiCRU\nZANhRESktkq5CmgmMDEIgcHM1gfjbcAuM9tQi8KUCCYi0r+6JIKFQXcCi4iUr9w7gbUWkIhIQqkB\niIgklBqAiEhCqQGIiCSUGoCISEKpAYiIJJQagIhIQqkBiIgkVE0XgyukgQGtwL34q4hOwg+IWWNm\ne2r5+SIi0r9aJ4K1AuuANfjJYLcEQTJrgEwF9YqISJXUNBHMzJabWTfQBtxDEAMZ/OXf0t/7RESk\n9gadAjKzxc65K4qGZgGrgseFRLANwaJxhr9yqAGrzaw7WDRutZltcc7tDpLCHLCpmhsiIiLlqWki\nWLDzvxnocs51AIuAqfgNIltJwSIiUh01PQlcNN9fbEstP1NEREqjRDARkYSKbCKYAmFERPpXl0CY\n4ORuFviCmS0JxuYAm4FxhbFqUiCMiNRDvjtPZoV/RXp2epZUUyrkioam3EAYJYKJSGJ5Sz3aN7YD\nkJ6QJjc7F3JFQ6NEMBERKYmOAEQksTQFFMEdrRqAiEj5NAUkIiIlUQMQEUkoNQARkYRSAxARSSg1\nABGRhKp3IhjFz81scy0/X0RE+lfvRLDi5zMHeJ+IiNRYvRLBpgD39Hq+bKjFi4hI5eqVCNZhZlvg\nQEjMgeciIhKOeieC7QG+AGxyznWY2fKKqhYRkSELIxGs93MREQmBEsFERBJKiWAiIg1IiWAiInKA\nloMWEUkoLQctIiIlUQMQEUkoNQARkYRSAxARSSg1ABGRhFIDEBFJKDUAEZGEUgMQEUmomjYA59y4\nIDjm80E6WGF8YS0/V0REBlfPRLCZwXtbOXhxORERCUE9E8GWBUcBu4MvEREJ0aANwMwW4yd/Fcyi\nZwdeSAQrHBVcXvRvUzBenAA2Dn8J6fHOudOqtREiIlK+uiaCmdly51wz0FxhvSIiUiV1TwQzsz3A\ntFp+roiIDE6JYCIiCaVEMBGRBqREMBEROUCJYCIiCaVEMBERKYkagIhIQqkBiIgklBqAiEhCqQGI\niCSUGoCISJF8dx5vqYe31CPfnQ+7nJrSZaAiIkW8pR7tG9sBSE9Ik5udC7mi0ukyUBERKUlNjwCC\n9f9b8INhlpnZliBfYBOw08w29PM+HQGISCjy3XkyKzIAZKdnSTWlQq6odDW5E9g5t8DMbil6PhM/\nE6AlyAvo732X468VNB4/N2A3PdkAA32eGoCISJmqPgVUpUSwNuAeYCJwThAa01pqkXET94XttH2N\nLc7bF+dtq0SpRwArzWxa8HgBsMrMOoPAl1YzuzM4KjD8lUMNWG1m3cFrdpjZBufcV4Gv4ofIZMzs\n1n4+L9ZHAEGXDruMmtH2NbY4b1+ctw3KPwKoayIY/s5/Kn6DWFRqkSIiUn11TwQDDmkUIiJSf0oE\nExFJqEqmgO7GP5nbiX+JZ0e1iwIqSrdpJNq+xqbta1xx3rZyDdoAgpO7E51zc8xsiZmtd85NDOb3\nd/V3Lf9QlHMSQ0REKhPJpSBERKT2tBSEiEhCqQGIlCC4/6X4+UznXFtwo2TD6719/Y01oj5+dnOD\nr7huX+F3c+Fg741UA3DOtTrn9jvnfuec2+ic+07YNVVb0Q9nTti1VJtz7ibn3OVx2SkWDOVu+EbQ\ne/v6G2tEffzs2vCXo1kMtDjnLg6tuCroZ/umBL+bLYP9bkaqAQCjzWyYmZ0OXAHcHnZB1RTsOLqC\nH87mRt9xFAt+8czMlgPjnXOnhVtR9QQ7i66ioVn461oRjE+pe1FV1Mf29TnWiPrYjhZ6fl5dwfOG\n1Xv7zGyNmd0YPB092EU6kWoAZtZZ9HTSYIvGNahCU2upxRVUIZpKzy/iJhp8p9iHQe+Gl+gzs8Vm\ntiR4eg7wRJj11IJzrtk5dxP+ygsDilQDKAj+mrw77DqqzczW4y+LsZP43UC3g4NvEBwfYi0iAwqO\nxp+M2R9hAJjZHjP7GvCJwY7EI9kAgKnBKqKx4pxrBjYCc4DFcZomAZbRs9MfT/wanO6Gj5e2/haj\nbGTBedTC1PJT+FPp/YpqAzgn7AJqJANkg3nyK4OvWDCzzcBPgr+sdhOD+eNeet8NX5g7bsHPvGh0\nfd18GZcbMg/aDufcXDO7M3jcFk5JVVW8fVM4+I+TAf8/jFwDCFLE4np3mhWObILzHbtCrqdqgh3/\npGCaqzlocrFQfDc8HJjKK+w8anI3fD313r7+xhpR7+0IfmYLgqsMd9Dg+5o+fk6L8K/+mYv/uzng\n/4eRuxM4aAA3F53JjpXg5MwmYEzRyahYCBLgwL/SqaF3iiJJELkGICIi9RG5KSAREakPNQARkYRS\nAxARSSg1ABGRhFIDEBFJKDUAEZGEUgMQEUkoNQARkYT6fxsnP+yg/VMzAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x1056b7750>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#plot galaxy abndance function\n",
-    "ext_mstar = np.linspace(7,12.2,50)\n",
-    "plt.figure()\n",
-    "plt.plot(mstar,dn)\n",
-    "plt.plot(ext_mstar,ab_func.dn(ext_mstar),'.')\n",
-    "plt.yscale('log')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(1081654,) (1081654,)\n",
-      "(1081654,) (1081654,)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "halotools/empirical_models/abundance_matching/abundance.py:196: RuntimeWarning: overflow encountered in exp\n",
-      "  return -1.0*np.exp(a*x+b) + c*x + d\n"
-     ]
-    }
-   ],
-   "source": [
-    "SHAM_model = abundance_matching.AbundanceMatching('mstar', 'halo_mvir', ab_func, complete_subhalo_catalog = halo_table, Lbox=250.0, scatter_level=0.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(1081654,) (1081654,)\n"
-     ]
-    }
-   ],
-   "source": [
-    "#caclulate empirical halo abundnace\n",
-    "cumu_x, x_centers = abundance_matching.empirical_cum_ndensity(halo_table['halo_mvir'],default_halocat.Lbox**3)\n",
-    "result = abundance_matching.AbundanceFunctionFromTabulated(\n",
-    "                            n = cumu_x, \n",
-    "                            x = x_centers, \n",
-    "                            type = 'cumulative', \n",
-    "                            n_increases_with_x = False)\n",
-    "                        "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEACAYAAAC6d6FnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHXFJREFUeJzt3Xl4VfWdx/H3D9FRWZIGl+rUkQSKAoLElEcsVdBE3ArT\nEioutWolqONo1QHqgiNxWsWWlmldaiV2sZVRKkxr7TwVZLOdUceFpRWprH2eqbbOQDCtu+13/vid\nyG3McnO337nnfF7Pk+fec3KX748bzvf+dmdmiIhI+vQJHYCIiIShBCAiklJKACIiKVX0BOCcq3bO\n1Rf7fUREpHeySgDOufkdjhudc/XOuaYsnj4NqMglOBERKZ4eE0B0kW/MOK4FzMxWRsdjeniJFXlF\nKCIiRdG3pweY2SLn3LSMU9OB5dH97UADsN451wgY4KLbx82sLTp2BY1aRETy1mMCiGRewCuB3RnH\ngwDMbGkXz20AqpxzK6KEICIiMZBtAsiZmX212O8hIiK9l+0ooMzpwq1AVXS/EthV0IhERKQkcmkC\nWgLUAauAGgrQyeuc03oUIiI5MLOc+1h7TABR526dc26GmbWY2TrnXF00tr/VzNbn+uaZ8l2TyDmX\n1Wt097jOfpfNuczjzu5nG1uucWf7uFzK11VZu3tMLkpVvt5+dr2JLde4s3lMV7+LQ/mK9dl1dj5N\n//c6HndVvnxkMwpoKbC0w7mWvN5VRESC22fevHmhY6C5uXlec3Mzzc3NAEycODGn18n2ed09rrPf\nZXMu87jj/ebmZgrx7xyqfF2Vtf223MrXm88OSlu+3pats/Mhylesz66z82n6v9fxuP3+mjVruPji\niwGYN29ec1bBdcLFYTlo55yFjuPll+GGG/zPsGGFfe1CVEPjTOUrb0kuX5LLBu+XL+d2IC0GFxkw\nAIYMgfHj4YIL4De/Kdxr33zzzYV7sRhS+cpbksuX5LIVgmoAHezZAwsXwp13whlnwNy5cPTRoaMS\nEfmgxNQAnHM45wrSXpePykpobobt2+Goo+DEE+G882DTpqBhiYi8b968eXmPAALVAHr0xz/62sDC\nhXDyyXDTTXDMMaGjEhFJUA0grgYMgOuv9zWCujqor/c1ghdfDB2ZiEh+lACy1L8/zJkDW7f6GsCE\nCXDuuWoaEpHypQTQSwMG+KGi27bB6NG+Wejcc2Hz5tCRiYj0TmwSQFw6gbPV3jS0bRuMGuU7i88/\nv7DDR0VEOqNO4Jhpa4M77oB//Vc4/XTfWVzoCWUiIpnUCRwTAwfCjTf6GsGwYX5C2YUX+j4DEZE4\nUgIosIED/bf/LVugpgbGjYOLLvKjiERE4kQJoEgqK+Hmm30N4MgjYexYuOQSJQIRiQ8lgCJrn1m8\nZQv87d/6RDBjBvz2t6EjE5G0UwIokaoquOUWnwgOPRRqa+Hyy+F//id0ZCKSVkoAJVZVBV/+Mrz0\nkh9KOno0XHMN/P73oSMTkbRRAgjkoIPgK1+BF14AMxgxAmbPhv/939CRiUhaKAEEdthhfu7Axo3w\n+ut+6em5c6G1NXRkIpJ0sUkA5TYTuNA+8hG4+2547jl45RX46Ed953FbW+jIRCRuNBM44bZu9Z3G\nP/85XHstXHkl9OsXOioRiRPNBE6ooUPh/vth7VpYt85vV7lwIbz5ZujIRCQpipoAnHPVzrl659ws\n51x1Md8rqYYPh4ceguXLYc0a3zR0zz3wzjuhIxORcpdVAnDOze9w3Bhd2Jt6eGot8AywEmjMLUQB\nP1z0Jz+Bf/93/3PUUXDfffDuu6EjE5Fy1WMCiC7yjRnHtYCZ2croeExXzzWzZWbWBjQAD+cfrowd\nC489Bj/8ITzwgB819L3vwXvvhY5MRMpNjwnAzBYBmSvYTAf2RPe34y/u7bWCqRm3A6Pz9cAKM9tZ\n0MhTbvx4WLUKvvMdnwBGjoQHH4S//CV0ZCJSLrLtA8jsZa4EdmccDwIws6XRN/7227bo4j8HuNQ5\nN7UwIUumCRNg9Wq46y7fSVxbC48+6ieXiYh0p6idwGa20sxOM7PLzWxZMd8rzZyDhgZ46ik/d+C6\n6+DjH/eJQUSkK9kmgMzvk61AVXS/EthV0IgkZ87Bpz7lZxX/4z9CU5NPDE8/HToyEYmjXJqAlgA1\n0f0a4PFCBNI+EzjtM4ILoU8fvz/xiy/C9OkwbRr8/d/7xCAi5al99m/mT756nAnsnGsE7gW+aGYt\n0bkZwA6guv1cXkFoJnBRvfUWfOtbcPvtMHGibyY66qjQUYlIvvKdCaylIFLkT3/yG9d//eswZQrM\nmwdHHBE6KhHJVWKWglDTT/H17w/XX+/3Ijj0UBgzBq66Cv7wh9CRiUhvaDE4ydurr8Ktt8IPfuB3\nJ5s9GyoqQkclItlKTA1ASu+QQ/xeBM8/D7/7nV9naMECLTgnkhZKAMKRR8J3v+vnDfzXf/mVSO+9\nV+sMiSRdbBKA+gDCGzkSli2DH//Yr0A6fDj8279peQmRuFEfgBTdqlW+0/jtt+FLX4KzzvKTzUQk\nHjQMVIrKzC9DPXeu7yC+9Va//pCIhKcEICXx5z/D4sVw880wbBjcdptfeE5EwtEoICmJffaBCy6A\nzZth8mQ480w45xzYti10ZCKSq9gkAHUCl4f99oMrrvCb1o8cCccf749///vQkYmkhzqBJRb+7/98\nv8D3vgeXXQZz5kBlZeioRNJBTUAS1EEH+bWFNmzwS0oMG+aP33ordGQi0hMlACmII47wm9SvWeN/\nhg/3cwlUsROJLzUBSVGsWQPXXAP9+vmtKseODR2RSPKoCUhiaeJEePZZuPhivxnN9OkaMSQSN0oA\nUjT77AOXXOJHDI0a5UcM/dM/wS5tIioSC0oAUnQHHuhnEv/qV/DGG3D00fC1r6mjWCQ0JQApmcMO\n81tTPvEErF3rE8HixeooFglFncASzBNP+I7iPn1g/nyorw8dkUh5SUwnsGYCp89JJ8Ezz/idyJqa\nfGfx5s2hoxKJP80ElkR56y2/Yf1XvgLnnQc33uh3LBORriWmBiDptv/+viawaZPvExg+HG65xXca\ni0hxFDUBOOcqnHP1zrnZzrmBxXwvSYaDD4ZvftM3DW3a5BPBkiXalUykGLJKAM65+R2OG6MLe1MP\nT60DngH2ADW5hShpVFMDDz4I3/8+3H47fPzjPimISOH0mACii3xjxnEtYGa2Mjoe09VzzWwV4IAK\nM1uff7iSNhMn+gv/ZZfBlCnw+c/Dyy+HjkokGXpMAGa2CNiecWo6/hs90fkGeL9WMDXjtsI512Rm\nrwHrnHOzCh28pEOfPnDRRX6E0MEHw+jRsGABvPNO6MhEylu2fQCZvcyVwO6M40EAZrbUzJZl3L4G\nPOOcqweqgYcLErGkVkWFbw568klYvRpGjIAf/UgTyURyVdROYDNbb2YrzazFzHYW870kPT76UfjZ\nz+Cee/wEshNOgPVqYBTptWwTQOZ3rFagKrpfCWhpLwmiocH3D1xyCZx+Olx4obamFOmNXJqAlrB3\nRE8N8HghAmmfCawZwdIbffr4WcRbtsCHPwzHHOP3H3jvvdCRiRRW++zfzJ989TgT2DnXCNwLfNHM\nWqJzM4AdQHX7ubyC0ExgKZCXXvKb1P/2t35ryk9+MnREIsWT70xgLQUhiWMGjz0GV18NQ4bAXXfB\n4MGhoxIpvMQsBaGmHykU53yfwMaNMH481NX5ZSW0/4AkhRaDE8nSzp1+J7ING+Ab34Azz/RJQqTc\nqQlIJEs//zlcdZVvDrrjDjjqqNARieQnMU1AIsV2+unwwgtwxhm+aeiGG+D110NHJRJObBKA+gCk\nFPbd1+9CtnGjHyk0YgQsW6bZxFJe1AcgUgBr1vhho0ccAXfeCUOHho5IJHtqAhLJw8SJfhmJhgYY\nNw5uvVWLzEl6KAFI6u27L8ya5ZeVePJJv9roihWhoxIpPjUBiXTw05/CF74Ao0b52cRDhoSOSKRz\niWkCUiewxMXkyX47yhNOgOOP90tQa20hiRN1AouUwI4dfrG53buhpQWOOy50RCJ7JaYGIBJH1dW+\nP+Cqq/wM4quvhjffDB2VSGEoAYj0wDm/JeWmTfCHP/glp3/xi9BRieRPTUAivfTIIzBzJnzmM36R\nuQ99KHREklZqAhIpsSlTfG3g7bf9TOIHH9RMYilPqgGI5OGpp3wncU0NfOtbcPjhoSOSNFENQCSg\ncePg+edh5EjfN7BgAfzlL6GjEsmOagAiBbJtG1xwAey3H9x9t28eEikm1QBEYmLIED86aOpUmDAB\nrr0W/vSn0FGJdC02CUAzgSUJ9tnHzxnYtAl27fLNQqtXh45KkkYzgUXKwE9/6pebPussv6TEwIGh\nI5IkUROQSIxNnuw3n3nvPd9R/MgjoSMS2askNQDn3D1mdlk3v1cNQBJv7Vq4+GI47TS/yugBB4SO\nSMpdSWoAzrn5HY4bnXP1zrmmLJ5bC+jqLqk3YQKsWwd79vhVRl94IXREknY9JoDoIt+YcVwLmJmt\njI7HdPPcamBP9COSehUVsHgxXHml343svvs0i1jC6TEBmNkiYHvGqensvaBvBxrg/VrB1IzbgUA1\nUAkMcc4NLmTgIuXKOT97eO1aWLgQzjnHLzctUmrZdgJntjFVApl/roMAzGypmS3LuG0zs1X4JFFR\nmHBFkmPECL8N5Yc/DHV1fjtKkVIq+iggM3vNzE4zs53Ffi+RcnPAAfCNb/hO4U9/Gm66SZvSS+lk\nmwAyWylbgarofiWwqxCBtE8E04QwSaNPf9p3EK9bB+PHw9atoSOSuGmf/JX5k6+shoE655ab2aTo\nfi1QZ2YtzrnZwAozW59XEBoGKgL4DuFvfhP+5V/gS1+CSy/1fQYinSn6MFDnXCNQ55ybAWBm66Lz\n9UBrvhd/EdnLOfjCF/yaQosW+b0HXn01dFSSVNmMAlpqZoPMrCXjXIuZrcw8ly81/YjsNXy47xQe\nNQqOPRYefTR0RBInWgtIJCWeeAI+9zm/Kf2CBXDggaEjkrjQWkAiCXfSSbBhw94ZxFu2hI5IkkIJ\nQKQMVFTAAw/AP/yDTwgbN4aOSJIgNglAfQAi3XMOLr8cvvY1qK+HO+/UMhJppT4AkRTbvBkuvBAG\nD/ajhbTPQDqpD0AkhY4+2q8lNGAAjB0L6zUYW3KgBCBSpvbfH1paYO5cmDQJ7r9fTULSO2oCEkmA\nX/8apk3zC8vdfz/83d+FjkhKQU1AIsIxx/gk0NAAn/gErFkTOiIpB7FJABoFJJKfvn19c9A998C5\n50JzM7z7buiopBg0CkhEuvTKK3DBBfD22/DjH8OgQaEjkmJQE5CIfMBhh8Hy5X6jmRNPhN/9LnRE\nEkdKACIJ1aeP33Lys5/1G9I//XToiCRu1AQkkgIPPQRXXeVnEX/2s6GjkULJtwmobyGDEZF4mj7d\nLy09YQK0tfk1hUSUAERSYsQIP3u4oQH69/edxNptLN3UBCSSMr/8pd9q8qyz4PbblQTKWb5NQEoA\nIim0a5dvDpo8GW67LXQ0kiv1AYhIrw0a5Hcaq6uDAw6Am25STSCNYjMMVDOBRUqrqsrPFfjRj+CK\nK7SQXDnRTGARKYi2NjjjDJ8QHnhAewuUE80EFpG8DBwIq1fD4Yf7heRefDF0RFIqRU0Azrlq59wS\n59yMYr6PiORnv/38InKf+5zfYOaXvwwdkZRCVk1Azrn5ZnZdxnEjsAeoMbNF3TxvMLDbzNp6eH01\nAYnExCOPwMyZPgkMHRo6GulO0ZuAnHNNQGPGcS1gZrYyOh7T1XPNbCcwyDnX5JyryDVIESmdKVP8\nshGXXAJvvBE6GimmHhNA9A1/e8ap6fhv/0TnG8DXCpxzUzNuK5xzjWa2A3gWaCpw7CJSJHPmQGUl\nnHIKbN0aOhoplmznAWRWMSqB3RnHgwDMbOkHnuTcc865eqAaeDjXIEWktPr2hSVL4I474NRT4amn\n4NBDQ0clhVbUiWBRE9DOYr6HiBTH3/wNzJoFr78OJ53k5wuMHh06KimkbEcBZfbQtgJV0f1KYFch\nAmmfCKYJYSLx8s//DNde6xeRu/vu0NGkV/vkr8yffGU7Cmi5mU2K7tcCdWbW4pybDawws/V5BaFR\nQCKxt307jB8Py5bBCSeEjkagNKOAGoG69rH8ZrYuOl8PtOZ78ReR8lBTA3fdBdOmQWtr6GikELIZ\nBbTUzAaZWUvGuRYzW5l5Ll9q+hGJv6lT4TOfgTPPhA0bQkeTXloLSESC+POf4dvfhptvhmefhSOP\nDB1Remk/ABEJ4sor/Wzhhx+GIUNCR5NOSgAiEsRbb0FzMzzzjJ8zUFXV83OksBKzGqj6AETKy/77\nw7x5fn/h884LHU26qA9ARGLh9dd9E9Dy5ZooVmqJqQGISHnq1w9uuQUmTYLnngsdjfSGEoCI5G3m\nTJg/388WXrgwdDSSLTUBiUjBbNgAn/yknzA2ZUroaJJPo4BEJFb+8z/9ZLFt2+CAA0JHk2yJ6QPQ\nKCCRZBg/HiZMgKuvDh1JcmkUkIjE1ssvw8iRsGOH31hGiiMxNQARSY7DD/dbSp54IqxYEToa6Ypq\nACJSFGZ+hvCFF8LmzTB4cOiIkkedwCISa5deCq+8Aj/4AVRUhI4mWdQEJCKx9uUvwx//6GsCv/pV\n6GgkkxKAiBTVQQfB4sVw7LFwyil+ZzGJBzUBiUjJzJsHv/gFPP44FGAUY+qpD0BEysY77/jhoYsX\nw9ixoaMpf+oDEJGysd9+MHkyPPZY6EgEYpQANBNYJB3q62HNmtBRlDfNBBaRsrRxI5x/vkYEFYKa\ngESkrNTUwKuvwksvhY5Eip4AnHNNzrlTnHNjiv1eIhJ//fvD1Kl+lrCElVUTkHNuvpldl3HcCOwB\nasxsUTfPawJWmNnOHl5fTUAiKbJ5s18naPFiOPXU0NGUr6I3AUUX8caM41rAzGxldNzdN/s64Djn\nXGP0PBERjj4a7rsPbrwxdCTp1mMCiL7hZ87dm47/9k90vgF8rcA5NzXjtgJoBR4HngfOLmjkIlLW\nTj7Z1wR27w4dSXr1zfJxmVWMSiDzIxsEYGZLP/Ak524DTgUM+HaOMYpIAg0YAKefDt/5DsyaFTqa\ndMo2AeTEzNqADyQGERGA2bPh7LN9TWDRIi0PUWrZjgLK7KFtBaqi+5XArkIE0j4RTBPCRNJj7Fh4\n4QX47/+Gn/0sdDTx1j75K/MnX9mOAlpuZpOi+7VAnZm1OOdm40f5rM8rCI0CEkm1WbOgXz9obg4d\nSXkpxSigRqDOOTcDwMzWRefrgdZ8L/4iIhddBHfd5ReLk9LJZhTQUjMbZGYtGedazGxl5rl8qelH\nJL2OOcbftrWFjaNcaC0gEUmUj3wEnnwSjjgidCTlQ2sBiUgiVFXBroIMKZFsKQGISCwMHQq/+U3o\nKNIlNglAfQAi6XbCCbB2begoyoP6AEQkUXbuhI99DHbs8LOEpWfqAxCRRBg8GMaNg//4j9CRpIcS\ngIjExsEHwxtvhI4iPZQARCQ29tkH3nsvdBTpoQQgIrHRt68SQCnFJgFoFJCIHHIIrF4NGhPSPY0C\nEpHEeeMNmDgRpkyBuXNDRxN/+Y4CKup+ACIivXHggfCTn/jRQEOHwjnnhI4o2ZQARCRWDjsMHn0U\nGhpg4EA488zQESVXbPoARETajRoFjzzil4lesyZ0NMmlBCAisXT88fDQQ37LyOeeCx1NMqkTWERi\n7b77YPFiWLkydCTxk28nsBKAiMTau+9CTY3vHD7uuNDRxIvWAhKRRNt3X7j6aliwIHQkyRObBKCJ\nYCLSlaYmeOwxePrp0JHEgyaCiUiqPPggXHON3zdg3jwYPTp0ROGpCUhEUuGcc2DbNvjEJ2DSJJg2\nDX7969BRlbeiJgDnXKNzbolz7h7n3KxivpeIJN+BB8K11/pEMG6cnyw2fTps2hQ6svKUVQJwzs3v\ncNzonKt3zjX18NTnzOxsYAlwb44xioj8lX79YNYs2LoV6urg5JPh3HPhxRdDR1ZeekwA0UW+MeO4\nFjAzWxkdj+nquWa2s/1pZtaWX6giIn+tf3+YM8fXCI49FiZMgPPP1+by2eoxAZjZImB7xqnpwJ7o\n/nagAd6vFUzNuB3Yfh7YVdiwRUT26t8frrvOJ4KRI+HEE+GHPwwdVfxluxhcZi9zJbA743gQgJkt\n7eK51cCK3ocmItI7AwbADTf4ZSSuucbXBgowWjKxij4KyMwWqPlHRErp5JP93gKaN9C9bBNA5iD9\nVqAqul+JmndEJGb69IGZM+FeDT3pVrYJILMStQSoie7XAI8XIpD2mcCaESwihXDRRbBsGezZ0+ND\ny0L77N/Mn3z1OBM46sS9F/iimbVE52YAO4Dq9nN5BaGZwCJSBNOnw0knwRVXhI6kOLQaqIhIF1at\n8gvJbdiQzM7gxCwFoaYfESm0iRPhzTfhqadCR1JYWgxORCQLX/2qXyriu98NHUnhqQlIRKQbr74K\nw4bBzp1QWRk6msJKTBOQiEgxHHIIfP7zsGVL6EjiJzYJQH0AIlIsX/86jB0bOorCUR+AiEjKqQlI\nRERyogQgIpJSSgAiIimlBCAiklKxSQAaBSQikh2NAhIRSTmNAhIRkZwoAYiIpJQSgIhISikBiIik\nlBKAiEhKKQGIiKSUEoCISErFJgFoIpiISHY0EUxEJOU0EUxERHLSt5gv7pyrAGqADwHbzWxnMd9P\nRESyl1UNwDk3v8Nxo3Ou3jnX1MNTPwY0AK1AwrZjFhEpbz0mgOgi35hxXAuYma2Mjsd08/RngSHA\nvcD2/EItX0nv2Fb5yluSy5fkshVCVp3AzrnHzOy06P58YLmZrXLO1QO1ZrbAOdcIGOCi25XA2Wa2\nKGoKmmlmX+3i9RPdCRx11IQOo2hUvvKW5PIluWyQfydwtn0AmW9QCezOOB4EYGZLOwlum3PuFHwT\n0IpcgxQRkcIr6iggM1sV/awzs/XFfK9sq3rdPa6z32VzLvO4q/v5ClW+rspa6Kp1qcoX4rPL9vV6\nW7bOzifpb7Oz80kqXxyuLbk0Ad0GrIiagBqBajNbkFcQBWgCyraq193jOvtdNucyjzu7X4hqaKjy\ndVXW7h6Ti1KVr7efXW9iyzXubB7T1e/iUL5ifXadnU/T/72Ox92Ur6RNQEuAOmAVfohnQZp2CjKr\nLcvX6O5xnf0um3OZx53dL+fydVXW7h6Ti1KVr7efXW9i6042r9HbsnV2PkT5ivXZdXY+Tf/3Oh4X\n+m+yxwQQfcuvc87NMLMWM1vnnKuLOoBbC9G0k08GExGR3MRiKQgRESk9LQUhIpJSsUoAzrnqqGkJ\n51yF87ONpzo/j6DsZZavs+Ny1+Hzq44+v1nOuerQsRVCF3+fs51zA0PHVgid/T065+4JFU8hdfK3\nucQ5NyN0XIXSybWlyTl3iut+om7pEoDLbjmJaUD7xf76aLbxSmBmicLMWQ7l6+w4tnIoXy3wDP7z\nayTmcihfHb58e/CDIWItl79PF836L1GIOcuhbAbMMLOWUsWYj96WLzq/IhqC320fbUkSgMt+OYnH\nM55WiX/Qa8T8P1iO5YMymRyXS/nMbJmZteHXgnq4hOH2Wo7lW4UfHVdR7Dku+cqlfFGtbU/0E1s5\nfnY7gUHRt+RYfwHL8dpSBxwXJYra7l6/JAnAzBbx12sBTWfvH9Z2/EWio1bn3MDoA9pW5BDz0svy\nuQ73Yz8CKtfyRVXSFXFfBTaXv0/nXFP05WSdc25W8aPMXY6fXzX+S9gQ59zgIoeYs1zK5pxrNLMd\n+LXKelrQMqhcr534hPA8cHZ3r1/KPoAel5PAF2Zs1Kb6beBUoB6/mFzcZVu+j2W0GXc8jrNelS+6\n+M8BLnXOTS1RjPno7d/nM1EZq4l5DSfSq88vquFspzyaKHv7f++56LOrI1mfXfvf5m34a2ct/jra\npaLuB9BbHRaLawN2BgqlKDouhtfV4njlqkN52vtvEqND+WLd7JOLTv4+XwNOCxROQaXt2gJ8YG22\nzpSyBpDZmdQKVEX3K4FdJYyjWFS+8qbyla8klw2KWL5QTUBL2NuxW8MHO0fLkcpX3lS+8pXkskER\ny1eqUUDvLycBYGbrovMFW04iJJVP5YuzJJcvyWWD4pdPS0GIiKRUrGYCi4hI6SgBiIiklBKAiEhK\nKQGIiKSUEoCISEopAYiIpJQSgIhISikBiIik1P8DFb7T8hHyhSIAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x11c9bc110>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.figure()\n",
-    "plt.plot(x_centers,cumu_x)\n",
-    "plt.yscale('log')\n",
-    "plt.xscale('log')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  }
- ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 2",
@@ -224,8 +16,261 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.11"
-  }
+  },
+  "name": "",
+  "signature": "sha256:1583482f38e9054f21b23023732de693573ce31847e1c52bf036b7d45dace021"
  },
- "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from halotools.empirical_models import abundance_matching\n",
+      "from halotools import sim_manager\n",
+      "import numpy as np\n",
+      "import matplotlib.pyplot as plt\n",
+      "%matplotlib inline  "
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "#load halo catalogue\n",
+      "default_halocat = sim_manager.CachedHaloCatalog() \n",
+      "halo_table = default_halocat.halo_table"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "#define schecter function\n",
+      "class Log_Schechter():\n",
+      "    \n",
+      "    def __init__(self, phi0, x0, alpha):\n",
+      "        self.phi0 = phi0\n",
+      "        self.x0 = x0\n",
+      "        self.alpha = alpha\n",
+      "    \n",
+      "    def __call__(self, x):\n",
+      "        x = np.asarray(x)\n",
+      "        x = x.astype(float)\n",
+      "        norm = np.log(10.0)*self.phi0\n",
+      "        val = norm*(10.0**((x-self.x0)*(1.0+self.alpha)))*np.exp(-10.0**(x-self.x0))\n",
+      "        return val\n",
+      "\n",
+      "#define galaxy abundance function\n",
+      "dn_gal = Log_Schechter(10**(-3),10.5,-1.4)\n",
+      "\n",
+      "#get tabulated form\n",
+      "mstar = np.linspace(8,12,100)\n",
+      "dn = dn_gal(mstar)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "params = {'n': dn, 'x': mstar, 'type': 'differential'}\n",
+      "ab_func = abundance_matching.AbundanceFunctionFromTabulated(**params)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "(100,) (100,)\n"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stderr",
+       "text": [
+        "/usr/local/lib/python2.7/site-packages/scipy/optimize/minpack.py:604: OptimizeWarning: Covariance of the parameters could not be estimated\n",
+        "  category=OptimizeWarning)\n",
+        "halotools/empirical_models/abundance_matching/abundance.py:220: RuntimeWarning: overflow encountered in exp\n",
+        "  return -1.0*np.exp(a*x+b) + c*x + d\n"
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "#plot galaxy abndance function\n",
+      "ext_mstar = np.linspace(7,12.2,50)\n",
+      "plt.figure()\n",
+      "plt.plot(mstar,dn)\n",
+      "plt.plot(ext_mstar,ab_func.dn(ext_mstar),'.')\n",
+      "plt.yscale('log')\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "display_data",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD7CAYAAABjVUMJAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHFNJREFUeJzt3XmUlPWV//H3ZacAKRbZBERUVAKTSFqNmRDKwQWbICrW\njJioUbESMxqToxOT6Ilm4oYxv+SnnqO2G2gotTPiKKOgHbXRUSdBhIwGtH8guCIi0IABAsL9/fFU\nQ6fTS3XX8tTyeZ3j0fpS9Tz3SbRufddr7o6IiJSfTmEHICIi4VACEBEpU0oAIiJlSglARKRMKQGI\niJQpJQARkTLVJewAmmNmWpsqItIB7m7pvrdgewCn/vZUNu/YjLvj7lz85MVMemBS2u2F/Ne1114b\negx6Pj2bnq/0/mqvgk0AC1ctJLEgse913cY6Fr+7OO32xIIEsTkxKudVUr+zvs12EZFyU5BDQAAV\nwyqomla173Wka6Rd7Q2JAYIv/ep4davtiQUJ6jbWEekaITkjSbRHtNm2lt4rIlJs8t4DMLPpZlZl\nZo+Y2Uktva/m3Jq/+WJNzkgSHxtPu72jCaNxTyIXvY4//m89hx4aY8MG2L27Hf/DFZFYLBZ2CDlT\nys8Ger5yYx0ZN8rKjc2iwK3uPquZP/NM46rfWU9iQYKqaVV/kxhaaq+cV8nCVQupGFaxL5k019bS\newFic2L7ehfxsfF9vYvG7SO3xen2RDWbN8Omf0xgA+voSoTRy5IM7B0lGoW3Dk/wl551RLpEuLBv\nkmH9o/TrB/d8nGDdrjr69Izw0PQkBw2IYmlP94hIqTMzvB2TwB1OAGZ2PzAV+MTdxzdqnwL8BugM\n3Ovus1v4/K3Ab919eTN/lnECaK/mEkM2kkhr7ZMeiPHie0FiOGlYnKvHVFNfD1etjPH2X4P2w/4a\n5/gPgoTx4ugYW/sH7Z1Wxun0WDXRKOw6JcHe/nV0twhf35BkcN8gYTwXSbC5Ux29ukW4dlySEQcG\n7T9/PcHabUG7hrBESkc+E8BE4DPgwYYEYGadgbeBE4EPgSXATKACmAD8ElgH3Aw86+7PtXDtvCeA\nbMh1wmja3tOi1NfDtMdiLNkQJIbjesc5r2eQMO7aGeODLkH7gZ/EOeiVoP39E2PsHRG0R9bEOfKN\navr1g9VfSLCzVx09O0c4NxL0MPr1gzkbE3y8u44+PSLMPS1IJJ0KdvmASPnKWwJI3WwUsKBRAjge\nuNbdp6Re/xjA3W9u9JnvA+cRJIfl7n53M9ctygTQXu1NGNlOJF8aVMF9k2rYuz3K5s1w+bIYK3cE\niWHM7jhfXx8kjN+PiLElGrR3eTuOV1fTty/snpLAB+zveQyJRnl1YIKtXYPexVWHJRk5KEr//nDT\nmwne+0sdvbur1yGSK2EngLOAU9z94tTrbwHHuftl7byuT5o0iVGjRjFq1ChisZgmb1qR70TSu0vQ\n86is/tuex7k9qvnlpzHeJWgbuinO6KXVbNoEq74WY/dBQXuPd+KMWV7NgAGwZlyCnb2D+Y5v90ky\nfGCQMO77JOh1HNAzwqP/nGRALyUMkaZqa2upra1l7dq1rF27lsWLF4eaAGYAU7KRAMqhB1Bo8jFx\nPmFwBXMm1/D5Z1E2bYLLlu7vdRy+K5jv2LgRXjw0xrbUfAd/jtPv99UMHAhbvp7g82gwTDWDIGEM\nHAiPbk/wyZ4gYTx0etCuCXIpN2H3AL4CXNdoCOgnwN6WJoJbua4SQBHI18T5onNqYGeUDRtg5jMx\nltcHiWF8pzgn1QcJ48kBMTYfELR3fitO1/+sZtAg2D45wZ5+QQ9jBklGDYkyeDDM2xokjL6RCL87\nO0m/nuphSPELOwF0IZgEngx8BPwRmOnuK9t5XSWAMpGrYaque4KEceaTMZZtDhLDOIszeVM1H38M\ni4bun9ewFXFG/E81Q4fCx8ck2H1AMFdx+fAkY0ZGGT4cZq9IsGarNv9JYcvnKqCHgUnAAOAT4Gfu\n/oCZncr+ZaD3uftNHbi2EoA0KxcJY0G8hh2bo6xbBxe/HGPF9v17NkYvrebDD2HVxBg+MmgfsjHO\nGZ9XM3Ik1PQIltr26x3hP2aqJyHhymsPIFeUACRbspUwTv1tJYtWL2RstIKrR9Sw6aMo774LcyzG\np732Dz0d+UY1hx4K76SW1PbrHeH+qUnGjtbSWck9JQCRDGSSMB6bHiSG1avh3/4cY42nVj2tjtN5\nfjU94gk6DaojGgk25h33xSijR6PEIFmjBCCSR+n2JDrtihKbs38+YsjG4EiQjRsh8i8Jugypo3/v\nCHeckOSrE6J06xbWE0kxUwIQKQDNJYbmhpfq64Ozov60JUgMB7wfZ3eymnHj4C+TE+yN1jFkQITH\nv6WJZ2mbEoBIgUq3t9B1T5TXX4fzX2g0jPROnBl7qonF4J/+CUaPDukhpKApAYgUmTYTw9AK7vxq\nDcv/J8oLL8DjnweH/w2KRrj5mCSnnRyld+8QH0AKhhKASIloKTE0PkV20IY42+dW87WvwbYTgiGj\naC/tVShX7U0Aoaw/MLNeZrbEzKaGcX+RYhDtEaU6Xv13X+S9uu0vavT2rVV8+CFccEFQqOjVdUGh\nosm/SbBpUxhRSzEJpQdgZj8HtgEr3f2pZv5cPQCRFrQ1ZHRYzwrGLavh+aejTJ4cHIexI6L6D+Wg\n4AvCpMpA9gd6AJ8qAYhkR9PEsGULVFfDFW/E2DYgGDKaNjrOk+dWhxyp5EoxFIT5HtALGAvsAM5o\n+m2vBCCSPQ09g4G7Kth1Xw2nnxLlyith/Pi2PyvFJezD4NosCNPos+cDG9z96Wb+TAlAJEsa9wz2\nbo9y111w++3Q9cwEA48I9hloaKg0hJ0AVBBGpAjs3AnjfxVj1eepmtRD4zyb0NBQscm0IEyXLMeT\ntZ/ttbW12bqUiDTRowccPirCqlUwsnMFf7qhinNq4aab4OCDw45O0tX0x7G1swpStpeBfgiMaPR6\nBPBBlu8hIlmQnJEkPjbOn66sYfWfo4wZAxMmwJevSzDxvhiV8yqp31kfdpiSQyoIIyL7vPcefPmO\n/Udcx8fGqY5raKhY5G0jWKogzCvAGDN738wucPfPgUuBZ4AVwKPt/fIXkfCMHAnHfDHYaNZtQwVd\nF1WxdWvIQUnO6CgIEfkbDauG/s8JVVx/TZRFi2DOHNA6jMKns4BEJKuefhpmzYIhFyfoM0o7iguZ\nEoCIZN26dXDULTG2RDU3UMiK4jA4ESkuQ4fC8V/ePzdw2aiqkCOSbFACEJG0PHxWsGz0rn+s4czK\nKI8/HnZEkikNAYlIuy1dCqedBj/9Kfzrv4YdjTTQHICI5MWaNTBlCkTOTnCAJocLghKAiOTNhg1w\nyL/H+MtATQ4XgoKfBLbADWZ2m5mdl+/7i0j2HHggfCU1OTxodwV3f0OTw8UkjEng04GDgF3onCCR\novcfZyc5/fA4Bz1fw40/i6LOe/HI5CiI+81svZm90aR9ipm9ZWb/z8yuauajY4CX3f1K4JKO3l9E\nCkO0R5THz6mmZkGwa/iGG8KOSNKVSQ/gAWBK44ZURbA7Uu1jgZlmdpSZnWtmvzazYQS/+huOGNyb\nwf1FpIAMGAA1NTB3LtxzT9jRSDo6XA/A3V9KnQba2LHAKndfC2BmjwDTUxXBHkq1zQduT5WUrO3o\n/UWk8AwZEhwdMXFiUFfg5JPDjkhak+2CMAcB7zd6/QFwXOM3uPsOYFZbF4rFYqoIJlKEDj8cHnsM\nJv/fBOPq6hjUT8tDc6VpRbD2ynY9gBnAlGyUhNQyUJHidtTsGG/t1PLQfAp7GagqgokIAIcMD5aH\n9v2sgjsrtTy0EGU7AbwGHG5mo8ysG/AvwJNZvoeIFIHkjCQzjowzblkNt92i4Z9C1OEhoFRFsEnA\nAOAT4Gfu/oCZnQr8BugM3OfuN3Xg2hoCEikRH38c1BpOJlVUJtd0FISIFJxFi+Dii2H58mC5qOSG\nEoCIFKQrroB33oH588HS/oqS9gh7ElhEpFk33girV8O8eWFHIg3UAxCRvFm6FL42O8HRJ9YR7aX9\nAdmmISARKWgHXxvjvU7aH5ALGgISkYJ25GHB/oBDe1RQNU37A8KkBCAiefVoPEnswDg776mhy+ca\n/gmThoBEJBTnnRccHnfLLWFHUjoKfg7AzIYDtwGbgTp3n93Me5QARErc+vUwfjy88AJ84QthR1Ma\nimEOYDzwmLtfBBwdwv1FpAAMHgxXXw1XXhl2JOUrjIpgrwAJM3sOWNTR+4tI8bvkEli1Cp59NuxI\nylMYFcEuAK5x98nA1AzuLyJFrls3mD076AXs2RN2NOWnwwnA3V8iGMdvbF9FMHffDTRUBHvI3X/o\n7h8BzwOXm9mdwJqO3l9ESsMZZ0DfvjBnTtiRlJ8wKoL9L3BWWxdSRTCR8mAWrAQ66bYEc62O3t21\nQzhdqggmIiWh/xUxNh+gHcKZCHsVkCqCiUiHHHlosEP4y0O0QzhfVBFMRArC0xcmGbopzlk7ajT8\nkyeqCCYiBWPZMpg6Fdasge7dw46m+BT8TuB0KAGIlK9TT4UZM2DWrLAjKT5KACJS1Gpr4TvfgRUr\noHPnsKMpLmFPAouIZGTSJIhG4Yknwo6k9CkBiEhBMYMf/SjYIayBgNxSAhCRgnP66bBpE7z8ctiR\nlDYlABEpOJ07w6WXwh13hB1JadMksIgUpC1b4JBD4M03YdiwsKMpDpoEFpGS0LcvzJwJd98ddiSl\nK6cJwMwOMbN7zex3qde9zGyumVWZ2Tm5vLeIFL9Pjktw08cxpjxUSf3O+rDDKTk5TQDuvsbdG2/n\nOBOodvcEcFou7y0ixW/D3jp2D1vMM+8sJLEgEXY4JSetBJBB9a+mGh8XrfIPItKqSNfggLg+23RA\nXC6k2wPoaPWvpj5g/2mhmn8QkVYlZyQ584g4XR+uYdNHOiAu29JeBdTM2f/HA9e6+5TU6x8DuPvN\njT7TH7gROBG4B7idIGnsBF5y94dbuJdWAYnIPj/4AfTpA7/4RdiRFLb2rgLKpCJYOtW/NgHfbfK5\nC9O5uCqCiUiDiy6Cykq47jqdD9RYphXBMkkAOf2JXltbm8vLi0gRGT8ehg6FZ58NTguVQNMfx2Zp\n//gHMhuHV/UvEcmbiy6C++8PO4rSkkkCUPUvEcmbeDzoAWzdGnYkpSPdZaAPA68AY8zsfTO7wN0/\nBy4FngFWAI+6+8rchSoi5ax/fzjhBJg/P+xISofOAhKRolFdDffeG/QE5O+pIpiIlKwdO4KD4Vau\nhCFDwo6m8OgwOBEpWT17wmmnwaOPhh1JaVACEJGi8s1vwrx5YUdRGjQEJCJF5fPPgz0Br70GBx8c\ndjSFRUNAIlLSunQJhoG0GihzSgAiUnQ+nJDgurUxKuepTkAmlABEpOhs71nH1v6LWbhKdQIykfME\n0ExVsOmpimCPmNlJub6/iJSe3t2DOgEju6hOQCbyNglsZr9z93ij11Hg1iYVwxr+TJPAItKi+p31\nVN6ZoNszVdQuUp2ABjmbBM5iVbAG1xDUBhARaZdojyg1iWqWvRpl48awoyle7RkCykpVMAvMBha6\n+/IMYheRMtarF8RisGhR2JEUr7QTgLu/BGxu0nwssMrd17r7buARYLq7P+TuP3T3j8ysv5ndBXwp\nVTXsUmAycJaZfSdLzyEiZegb34Cnngo7iuKVSUEY6HhVsNvburAqgolIWyor4aqrgs1hXTL9NitC\nYVYEgxxWBVNFMBFpy0EHwahR8OqrMHFi2NHkX5gVwUBVwUQkZFOnwn/9V9hRFKdME4CqgolIqDQP\n0HHtWQaqqmAiUnCOOQY2bIAODIGXPZ0GKiJF79vfhmOPhe99L+xIwqXTQEWk7Jx8MtTUhB1F8VEP\nQESK3vr1cOSRwVBQOS4HbaAegIiUncGDYeRIWLIk7EiKixKAiJSEk07SMFB7KQGISElQAmg/zQGI\nSEnYvh0GDYJ166BPn7CjCYfmAESkLEUiwVLQxYvDjqR45DQBNK0GlmrrZWZLzGxqLu8tIuVHw0Dt\nk9ME4O5rmqn49SPg0VzeV0TK0x8GJbh3j4rFpyutBJCtamCpGsArgA0dC1dEpGWbrI7tB6pYfLrS\n7QFkpRoYMAn4CnAOcLG19+xSEZFWNBSLP6ynisWnI609c+7+kpmNatK8rxoYgJk1VAO7GXgo1dYf\nuJGgGthV7n5Nqv18YIOW+ohINiVnJJl4S4KJH1cR7aFi8W3JZNN0R6uB4e5z27q4KoKJSHtFe0S5\na3I13/9+2JHkR5gVwXL6610VwUSkIyoq4O23YcsW6Ns37GhyK8yKYKoGJiIFp3v3YD/Af/932JEU\nvkwSgKqBiUhBmjQJXnwx7CgKX7rLQFUNTESKxqRJ2hGcDp0FJCIlZ8cOGDgQPv0UevYMO5r80VlA\nIlL2evaEcePgtdfCjqSwKQGISEk6/nh45ZWwoyhsSgAiUpKOPx5efTXsKAqbEoCIlKSGBKDpxJYp\nAYhISRoxArp2hTVrwo6kcCkBiEhJMtM8QFuUAESkZGkeoHV5rQhmZp3M7AYzu83MzsvlvUVElABa\nl++KYNMJThHdhc4NEpEcmzAhOBjus8/CjqQw5bUiGDAGeNndrwQu6UC8IiJp694d/uEfYOnSsCMp\nTPmuCPYB0FCoc28HYxYRSVtFhRJAS9JKAO7+ErC5SfO+imDuvhtoqAj2kLv/0N0/MrP+ZnYXcHSq\nhzAfOMXMbgNqs/cYIiLNq6iAJUvCjqIwhVERbBZpUEUwEcmGY46B668PO4rcUEUwEZFWHHEErF8P\nmzdDv35hR5NdqggmItKKzp3h6KM1D9AcVQQTkZJXUaGjoZujimAiUvKWDU/wq40xKudVUr+zvu0P\nlAlVBBORknfcnTH++ElQIzI+Nk51vDrkiHJDFcFERJro3ycCwJcOrKBqWlXI0RQOJQARKXkPn5Vk\n0IY4Px1RQ7RHNOxwCkYmy0BFRIpCtEeUn4+rplfnsCMpLJoDEBEpEZoDEBGRtCgBiIiUqXwXhBlu\nZvPN7L40j48WEZEcyXdBmPHAY+5+EXB0Lu8tIiKty3dBmFeAhJk9ByzqQLwiIpIl+S4IcwFwjbtP\nBqZmELeIiGQoXwVhvpTqITwPXG5mdwJrsvgcIiLSTmEUhDkrnYurIIyISOtUEEZEpEypIIyIiHSI\nCsKIiJQpFYQRESlTOgxORKRE6DA4ERFJixKAiEiZUgIQESlTSgAiImVKCUBEpEwpAYiIlCklABGR\nMpXJWUBtMrPpBMc+HwDcB7wM3An8Fah192Qu7y8iIi3Ly0YwM4sCtwK1wGZ3f8rMHnH3s1t4vzaC\niYi0U042gmWhItg1BMVjhrP/wLg96QYpIiLZl9OKYBaYDSx09+UEX/7D23lvERHJgbTmANz9JTMb\n1aR5X0UwADNrqAh2M/BQqu37wGTgADM7LNV+h5lNRSeHioiEKtcVwW4DbmvyuQvTubgqgomItE4V\nwUREylSmFcEySQCqCCYiRS2xIEHdxjoiXSMkZySJ9oiGHVJeqSKYiJStuo11LH53MQtXLSSxIBF2\nOHmnimAiUrYiXSMAVAyroGpaVcjR5J8qgolI2arfWU9iQYKqaVUlMfzT3o1gSgAiIiVCJSFFRCQt\nSgAiImVKCUBEpEwpAYiIlCklABGRMqUEICJSpnJaEQyarQoWafza3WtyHYOIiPy9vO0DaKgK5u6z\nmnvd5L3aByAi0k452weQxapgLb0WEZE8as8cQFaqgjVTJUxEREKQ9hxAFquCdWv82t3vzvQhRESk\n/TKdBO5oVbDb27qwKoKJiLQuzIpgkMOqYKoIJiLSukwrgmW6D0BVwUREilSmCUBVwUREilR7loGq\nKpiISAlRQRgRkRKhgjAiIpIWJQARkTKlBCAiUqaUAEREypQSgIhImVICEBEpU0oAIiJlKqcJwMym\nm1mVmT1iZiel2nqZ2RIzm5rLe4uISOvyshGscfUvM/s5sA1Y6e5PtfB+bQQTEWmnnGwEy1Y1sFQv\nYAWwId0ARUQkN9LqAZjZROAz4EF3H59q6wy8DZxIcCroEmAmUAFMAH4JrANuBp519+fM7HqgF0H1\nsB3AGc391FcPQESk/drbA0irHkC2qoG5+zWp9vOBDfqWFxEJTyYFYTpaDQx3n9vWxVURTESkdWFW\nBMvpr3dVBBMRaV2YFcFUDUxEpIhlkgBUDUxEpIiluwxU1cBEREqMKoKJiJQIVQQTEZG0KAGIiJQp\nJQARkTKVyT4AEZGSlFiQoG5jHZGuEZIzkkR7RMMOKSfUAxARaaJuYx2L313MwlULSSxIhB1OzigB\niIg0EekaAaBiWAVV06pCjiZ3tAxURKSJ+p31JBYkqJpWVVTDP+1dBprTBGBm04GpwAHAfcDvgeuB\nPsBr7v5gC59TAhARaaeC2gfg7k+4ewL4LsFREdMJThHdRRmfG1TqB92V8vOV8rOBnq/c5LUiGHAE\n8LK7Xwlc0uGoi1yp/0tYys9Xys8Ger5yk24P4AFgSuOGVEWwO1LtY4GZZnaUmZ1rZr82s2EWmA0s\ndPflBL/661OX2JudRxARkY7Ia0Uw4EHg9lSJydosxC8iIh2U9iRwKgEsaFQT+CzgFHe/OPX6W8Bx\n7n5ZxkGZaQZYRKQDsl4TuKX7ZPDZ1i/cjgcQEZGOUUUwEZEypYpgIiJlqqAqgpnZEWa2rNFfW1IT\nySXBzH5iZn82szfMLGlm3cOOKZvM7PLUs71pZpeHHU+mmlv+bGb9zazGzOrM7FkzK55tok208Hzx\n1L+je8xsQpjxZaqF5/ulma00sz+Z2Xwz6xtmjB3VwrP9IvVcy83sOTMb0do1oECPggAws04Ew0zH\nuvv7YceTqdQk+vPAUe7+VzN7FHja3eeGGliWmNk44GHgGGA3sAj4rruvDjWwDKRWq30GPNho8cMt\nwKfufktq70s/d/9xmHF2VAvPdyTBEu27gSvc/fUQQ8xIC893EvCcu+81s5sBivH/vxaerY+7b0v9\n82XAF919VmvXKeTD4E4EVpfCl3/KVoIvxoiZdQEiBAmuVBwJ/MHdd7r7HmAxcGbIMWXE3V8CNjdp\nPg1oSNpzgdPzGlQWNfd87v6Wu9eFFFJWtfB8Ne7esAfpD8DwvAeWBS0827ZGL3sDn7Z1nUJOAGcD\nybCDyBZ33wT8CngP+Aiod/ffhxtVVr0JTEwNkUQIzoAqyv+42jDY3den/nk9MDjMYCQjFwJPhx1E\nNpnZDWb2HnA+cHNb7y/IBJCaVJ4G/C7sWLLFzA4FfgCMAoYBvc3sm6EGlUXu/hYwG3gWWAgso8R3\ne6dOLCzMMVRplZldDexy95L5kQng7le7+0hgDvDrtt5fkAkAOBVY6u4bwg4kiyqAV9x9Y2oCfT7w\n1ZBjyip3v9/dK9x9EsGRH2+HHVMOrDezIQBmNhT4JOR4pJ3M7NtAJVAyP8CakSSYj2tVoSaAmQQT\niqXkLeArZtbTzIxgjmNFyDFllZkNSv19JHAGJTSE18iTBN1rUn//zxBjybWS25BpZlOAfyM4tmZn\n2PFkk5kd3ujldIJeeOufKbRVQGbWC3gXOKTJpEbRM7MfEXxp7AVeB2a5++5wo8oeM3sRGEAw2f1D\nd38h5JAyklr+PAkYSDDe/zPgCaAaGAmsBf7Z3etbukYha+b5rgU2Aben2rYAy9z91NCCzEALz/cT\noBvBcwK86u7fCyfCjmvh2SoJTlzeA6wGLnH3VnuoBZcAREQkPwp1CEhERHJMCUBEpEwpAYiIlCkl\nABGRMqUEICJSppQARETKlBKAiEiZUgIQESlT/x+ndlXsN//DpwAAAABJRU5ErkJggg==\n",
+       "text": [
+        "<matplotlib.figure.Figure at 0x103c34250>"
+       ]
+      }
+     ],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "galprop_sample_values = np.linspace(7,12.2,50)\n",
+      "haloprop_sample_values = np.logspace(11,14.5,50)\n",
+      "\n",
+      "SHAM_model = abundance_matching.AbundanceMatching('mstar', \n",
+      "                                                  'halo_mvir', \n",
+      "                                                  ab_func, \n",
+      "                                                  galprop_sample_values, haloprop_sample_values,\n",
+      "                                                  complete_subhalo_catalog = halo_table, \n",
+      "                                                  Lbox=250.0, scatter_level=0.0)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "(1081654,) (1081654,)\n",
+        "(1081654,)"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        " (1081654,)\n"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stderr",
+       "text": [
+        "halotools/empirical_models/abundance_matching/abundance.py:196: RuntimeWarning: overflow encountered in exp\n",
+        "  return -1.0*np.exp(a*x+b) + c*x + d\n"
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "SHAM_model.mean_mstar(prim_haloprop = [1e12, 1e13])"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "ename": "ValueError",
+       "evalue": "A value in x_new is below the interpolation range.",
+       "output_type": "pyerr",
+       "traceback": [
+        "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+        "\u001b[0;32m<ipython-input-7-087256fa80ec>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mSHAM_model\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmean_mstar\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mprim_haloprop\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m1e12\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1e13\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+        "\u001b[0;32m/Users/aphearin/work/repositories/python/halotools/halotools/empirical_models/abundance_matching/abundance_matching.py\u001b[0m in \u001b[0;36m_galprop_from_haloprop\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    109\u001b[0m         func = self.match(\n\u001b[1;32m    110\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgalaxy_abundance_function\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhalo_abundance_function\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 111\u001b[0;31m             self.galprop_sample_values, self.haloprop_sample_values)\n\u001b[0m\u001b[1;32m    112\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    113\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhalo_mass\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+        "\u001b[0;32m/Users/aphearin/work/repositories/python/halotools/halotools/empirical_models/abundance_matching/abundance_matching.py\u001b[0m in \u001b[0;36mmatch\u001b[0;34m(self, n1, n2, x1, x2)\u001b[0m\n\u001b[1;32m    150\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    151\u001b[0m         \u001b[0;31m#calculate the value of x2 at the abundances of x1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 152\u001b[0;31m         \u001b[0mx2n\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0minverted_n2\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    153\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    154\u001b[0m         \u001b[0;31m#get x1 as a function of x2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+        "\u001b[0;32m/usr/local/lib/python2.7/site-packages/scipy/interpolate/polyint.pyc\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \"\"\"\n\u001b[1;32m     78\u001b[0m         \u001b[0mx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx_shape\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_prepare_x\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         \u001b[0my\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_evaluate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_finish_y\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx_shape\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+        "\u001b[0;32m/usr/local/lib/python2.7/site-packages/scipy/interpolate/interpolate.pyc\u001b[0m in \u001b[0;36m_evaluate\u001b[0;34m(self, x_new)\u001b[0m\n\u001b[1;32m    496\u001b[0m         \u001b[0;31m#    The behavior is set by the bounds_error variable.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    497\u001b[0m         \u001b[0mx_new\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0masarray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx_new\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 498\u001b[0;31m         \u001b[0mout_of_bounds\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_check_bounds\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx_new\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    499\u001b[0m         \u001b[0my_new\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mx_new\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    500\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my_new\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+        "\u001b[0;32m/usr/local/lib/python2.7/site-packages/scipy/interpolate/interpolate.pyc\u001b[0m in \u001b[0;36m_check_bounds\u001b[0;34m(self, x_new)\u001b[0m\n\u001b[1;32m    523\u001b[0m         \u001b[0;31m# !! Could provide more information about which values are out of bounds\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    524\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbounds_error\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mbelow_bounds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0many\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 525\u001b[0;31m             raise ValueError(\"A value in x_new is below the interpolation \"\n\u001b[0m\u001b[1;32m    526\u001b[0m                 \"range.\")\n\u001b[1;32m    527\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbounds_error\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mabove_bounds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0many\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+        "\u001b[0;31mValueError\u001b[0m: A value in x_new is below the interpolation range."
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "#caclulate empirical halo abundnace\n",
+      "cumu_x, x_centers = abundance_matching.empirical_cum_ndensity(halo_table['halo_mvir'],default_halocat.Lbox**3)\n",
+      "result = abundance_matching.AbundanceFunctionFromTabulated(\n",
+      "                            n = cumu_x, \n",
+      "                            x = x_centers, \n",
+      "                            type = 'cumulative', \n",
+      "                            n_increases_with_x = False)\n",
+      "                        "
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "(1081654,) (1081654,)\n"
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "plt.figure()\n",
+      "plt.plot(x_centers,cumu_x)\n",
+      "plt.yscale('log')\n",
+      "plt.xscale('log')\n",
+      "plt.show()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "display_data",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEACAYAAAC6d6FnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHXFJREFUeJzt3Xl4VfWdx/H3D9FRWZIGl+rUkQSKAoLElEcsVdBE3ArT\nEioutWolqONo1QHqgiNxWsWWlmldaiV2sZVRKkxr7TwVZLOdUceFpRWprH2eqbbOQDCtu+13/vid\nyG3McnO337nnfF7Pk+fec3KX748bzvf+dmdmiIhI+vQJHYCIiIShBCAiklJKACIiKVX0BOCcq3bO\n1Rf7fUREpHeySgDOufkdjhudc/XOuaYsnj4NqMglOBERKZ4eE0B0kW/MOK4FzMxWRsdjeniJFXlF\nKCIiRdG3pweY2SLn3LSMU9OB5dH97UADsN451wgY4KLbx82sLTp2BY1aRETy1mMCiGRewCuB3RnH\ngwDMbGkXz20AqpxzK6KEICIiMZBtAsiZmX212O8hIiK9l+0ooMzpwq1AVXS/EthV0IhERKQkcmkC\nWgLUAauAGgrQyeuc03oUIiI5MLOc+1h7TABR526dc26GmbWY2TrnXF00tr/VzNbn+uaZ8l2TyDmX\n1Wt097jOfpfNuczjzu5nG1uucWf7uFzK11VZu3tMLkpVvt5+dr2JLde4s3lMV7+LQ/mK9dl1dj5N\n//c6HndVvnxkMwpoKbC0w7mWvN5VRESC22fevHmhY6C5uXlec3Mzzc3NAEycODGn18n2ed09rrPf\nZXMu87jj/ebmZgrx7xyqfF2Vtf223MrXm88OSlu+3pats/Mhylesz66z82n6v9fxuP3+mjVruPji\niwGYN29ec1bBdcLFYTlo55yFjuPll+GGG/zPsGGFfe1CVEPjTOUrb0kuX5LLBu+XL+d2IC0GFxkw\nAIYMgfHj4YIL4De/Kdxr33zzzYV7sRhS+cpbksuX5LIVgmoAHezZAwsXwp13whlnwNy5cPTRoaMS\nEfmgxNQAnHM45wrSXpePykpobobt2+Goo+DEE+G882DTpqBhiYi8b968eXmPAALVAHr0xz/62sDC\nhXDyyXDTTXDMMaGjEhFJUA0grgYMgOuv9zWCujqor/c1ghdfDB2ZiEh+lACy1L8/zJkDW7f6GsCE\nCXDuuWoaEpHypQTQSwMG+KGi27bB6NG+Wejcc2Hz5tCRiYj0TmwSQFw6gbPV3jS0bRuMGuU7i88/\nv7DDR0VEOqNO4Jhpa4M77oB//Vc4/XTfWVzoCWUiIpnUCRwTAwfCjTf6GsGwYX5C2YUX+j4DEZE4\nUgIosIED/bf/LVugpgbGjYOLLvKjiERE4kQJoEgqK+Hmm30N4MgjYexYuOQSJQIRiQ8lgCJrn1m8\nZQv87d/6RDBjBvz2t6EjE5G0UwIokaoquOUWnwgOPRRqa+Hyy+F//id0ZCKSVkoAJVZVBV/+Mrz0\nkh9KOno0XHMN/P73oSMTkbRRAgjkoIPgK1+BF14AMxgxAmbPhv/939CRiUhaKAEEdthhfu7Axo3w\n+ut+6em5c6G1NXRkIpJ0sUkA5TYTuNA+8hG4+2547jl45RX46Ed953FbW+jIRCRuNBM44bZu9Z3G\nP/85XHstXHkl9OsXOioRiRPNBE6ooUPh/vth7VpYt85vV7lwIbz5ZujIRCQpipoAnHPVzrl659ws\n51x1Md8rqYYPh4ceguXLYc0a3zR0zz3wzjuhIxORcpdVAnDOze9w3Bhd2Jt6eGot8AywEmjMLUQB\nP1z0Jz+Bf/93/3PUUXDfffDuu6EjE5Fy1WMCiC7yjRnHtYCZ2croeExXzzWzZWbWBjQAD+cfrowd\nC489Bj/8ITzwgB819L3vwXvvhY5MRMpNjwnAzBYBmSvYTAf2RPe34y/u7bWCqRm3A6Pz9cAKM9tZ\n0MhTbvx4WLUKvvMdnwBGjoQHH4S//CV0ZCJSLrLtA8jsZa4EdmccDwIws6XRN/7227bo4j8HuNQ5\nN7UwIUumCRNg9Wq46y7fSVxbC48+6ieXiYh0p6idwGa20sxOM7PLzWxZMd8rzZyDhgZ46ik/d+C6\n6+DjH/eJQUSkK9kmgMzvk61AVXS/EthV0IgkZ87Bpz7lZxX/4z9CU5NPDE8/HToyEYmjXJqAlgA1\n0f0a4PFCBNI+EzjtM4ILoU8fvz/xiy/C9OkwbRr8/d/7xCAi5al99m/mT756nAnsnGsE7gW+aGYt\n0bkZwA6guv1cXkFoJnBRvfUWfOtbcPvtMHGibyY66qjQUYlIvvKdCaylIFLkT3/yG9d//eswZQrM\nmwdHHBE6KhHJVWKWglDTT/H17w/XX+/3Ijj0UBgzBq66Cv7wh9CRiUhvaDE4ydurr8Ktt8IPfuB3\nJ5s9GyoqQkclItlKTA1ASu+QQ/xeBM8/D7/7nV9naMECLTgnkhZKAMKRR8J3v+vnDfzXf/mVSO+9\nV+sMiSRdbBKA+gDCGzkSli2DH//Yr0A6fDj8279peQmRuFEfgBTdqlW+0/jtt+FLX4KzzvKTzUQk\nHjQMVIrKzC9DPXeu7yC+9Va//pCIhKcEICXx5z/D4sVw880wbBjcdptfeE5EwtEoICmJffaBCy6A\nzZth8mQ480w45xzYti10ZCKSq9gkAHUCl4f99oMrrvCb1o8cCccf749///vQkYmkhzqBJRb+7/98\nv8D3vgeXXQZz5kBlZeioRNJBTUAS1EEH+bWFNmzwS0oMG+aP33ordGQi0hMlACmII47wm9SvWeN/\nhg/3cwlUsROJLzUBSVGsWQPXXAP9+vmtKseODR2RSPKoCUhiaeJEePZZuPhivxnN9OkaMSQSN0oA\nUjT77AOXXOJHDI0a5UcM/dM/wS5tIioSC0oAUnQHHuhnEv/qV/DGG3D00fC1r6mjWCQ0JQApmcMO\n81tTPvEErF3rE8HixeooFglFncASzBNP+I7iPn1g/nyorw8dkUh5SUwnsGYCp89JJ8Ezz/idyJqa\nfGfx5s2hoxKJP80ElkR56y2/Yf1XvgLnnQc33uh3LBORriWmBiDptv/+viawaZPvExg+HG65xXca\ni0hxFDUBOOcqnHP1zrnZzrmBxXwvSYaDD4ZvftM3DW3a5BPBkiXalUykGLJKAM65+R2OG6MLe1MP\nT60DngH2ADW5hShpVFMDDz4I3/8+3H47fPzjPimISOH0mACii3xjxnEtYGa2Mjoe09VzzWwV4IAK\nM1uff7iSNhMn+gv/ZZfBlCnw+c/Dyy+HjkokGXpMAGa2CNiecWo6/hs90fkGeL9WMDXjtsI512Rm\nrwHrnHOzCh28pEOfPnDRRX6E0MEHw+jRsGABvPNO6MhEylu2fQCZvcyVwO6M40EAZrbUzJZl3L4G\nPOOcqweqgYcLErGkVkWFbw568klYvRpGjIAf/UgTyURyVdROYDNbb2YrzazFzHYW870kPT76UfjZ\nz+Cee/wEshNOgPVqYBTptWwTQOZ3rFagKrpfCWhpLwmiocH3D1xyCZx+Olx4obamFOmNXJqAlrB3\nRE8N8HghAmmfCawZwdIbffr4WcRbtsCHPwzHHOP3H3jvvdCRiRRW++zfzJ989TgT2DnXCNwLfNHM\nWqJzM4AdQHX7ubyC0ExgKZCXXvKb1P/2t35ryk9+MnREIsWT70xgLQUhiWMGjz0GV18NQ4bAXXfB\n4MGhoxIpvMQsBaGmHykU53yfwMaNMH481NX5ZSW0/4AkhRaDE8nSzp1+J7ING+Ab34Azz/RJQqTc\nqQlIJEs//zlcdZVvDrrjDjjqqNARieQnMU1AIsV2+unwwgtwxhm+aeiGG+D110NHJRJObBKA+gCk\nFPbd1+9CtnGjHyk0YgQsW6bZxFJe1AcgUgBr1vhho0ccAXfeCUOHho5IJHtqAhLJw8SJfhmJhgYY\nNw5uvVWLzEl6KAFI6u27L8ya5ZeVePJJv9roihWhoxIpPjUBiXTw05/CF74Ao0b52cRDhoSOSKRz\niWkCUiewxMXkyX47yhNOgOOP90tQa20hiRN1AouUwI4dfrG53buhpQWOOy50RCJ7JaYGIBJH1dW+\nP+Cqq/wM4quvhjffDB2VSGEoAYj0wDm/JeWmTfCHP/glp3/xi9BRieRPTUAivfTIIzBzJnzmM36R\nuQ99KHREklZqAhIpsSlTfG3g7bf9TOIHH9RMYilPqgGI5OGpp3wncU0NfOtbcPjhoSOSNFENQCSg\ncePg+edh5EjfN7BgAfzlL6GjEsmOagAiBbJtG1xwAey3H9x9t28eEikm1QBEYmLIED86aOpUmDAB\nrr0W/vSn0FGJdC02CUAzgSUJ9tnHzxnYtAl27fLNQqtXh45KkkYzgUXKwE9/6pebPussv6TEwIGh\nI5IkUROQSIxNnuw3n3nvPd9R/MgjoSMS2askNQDn3D1mdlk3v1cNQBJv7Vq4+GI47TS/yugBB4SO\nSMpdSWoAzrn5HY4bnXP1zrmmLJ5bC+jqLqk3YQKsWwd79vhVRl94IXREknY9JoDoIt+YcVwLmJmt\njI7HdPPcamBP9COSehUVsHgxXHml343svvs0i1jC6TEBmNkiYHvGqensvaBvBxrg/VrB1IzbgUA1\nUAkMcc4NLmTgIuXKOT97eO1aWLgQzjnHLzctUmrZdgJntjFVApl/roMAzGypmS3LuG0zs1X4JFFR\nmHBFkmPECL8N5Yc/DHV1fjtKkVIq+iggM3vNzE4zs53Ffi+RcnPAAfCNb/hO4U9/Gm66SZvSS+lk\nmwAyWylbgarofiWwqxCBtE8E04QwSaNPf9p3EK9bB+PHw9atoSOSuGmf/JX5k6+shoE655ab2aTo\nfi1QZ2YtzrnZwAozW59XEBoGKgL4DuFvfhP+5V/gS1+CSy/1fQYinSn6MFDnXCNQ55ybAWBm66Lz\n9UBrvhd/EdnLOfjCF/yaQosW+b0HXn01dFSSVNmMAlpqZoPMrCXjXIuZrcw8ly81/YjsNXy47xQe\nNQqOPRYefTR0RBInWgtIJCWeeAI+9zm/Kf2CBXDggaEjkrjQWkAiCXfSSbBhw94ZxFu2hI5IkkIJ\nQKQMVFTAAw/AP/yDTwgbN4aOSJIgNglAfQAi3XMOLr8cvvY1qK+HO+/UMhJppT4AkRTbvBkuvBAG\nD/ajhbTPQDqpD0AkhY4+2q8lNGAAjB0L6zUYW3KgBCBSpvbfH1paYO5cmDQJ7r9fTULSO2oCEkmA\nX/8apk3zC8vdfz/83d+FjkhKQU1AIsIxx/gk0NAAn/gErFkTOiIpB7FJABoFJJKfvn19c9A998C5\n50JzM7z7buiopBg0CkhEuvTKK3DBBfD22/DjH8OgQaEjkmJQE5CIfMBhh8Hy5X6jmRNPhN/9LnRE\nEkdKACIJ1aeP33Lys5/1G9I//XToiCRu1AQkkgIPPQRXXeVnEX/2s6GjkULJtwmobyGDEZF4mj7d\nLy09YQK0tfk1hUSUAERSYsQIP3u4oQH69/edxNptLN3UBCSSMr/8pd9q8qyz4PbblQTKWb5NQEoA\nIim0a5dvDpo8GW67LXQ0kiv1AYhIrw0a5Hcaq6uDAw6Am25STSCNYjMMVDOBRUqrqsrPFfjRj+CK\nK7SQXDnRTGARKYi2NjjjDJ8QHnhAewuUE80EFpG8DBwIq1fD4Yf7heRefDF0RFIqRU0Azrlq59wS\n59yMYr6PiORnv/38InKf+5zfYOaXvwwdkZRCVk1Azrn5ZnZdxnEjsAeoMbNF3TxvMLDbzNp6eH01\nAYnExCOPwMyZPgkMHRo6GulO0ZuAnHNNQGPGcS1gZrYyOh7T1XPNbCcwyDnX5JyryDVIESmdKVP8\nshGXXAJvvBE6GimmHhNA9A1/e8ap6fhv/0TnG8DXCpxzUzNuK5xzjWa2A3gWaCpw7CJSJHPmQGUl\nnHIKbN0aOhoplmznAWRWMSqB3RnHgwDMbOkHnuTcc865eqAaeDjXIEWktPr2hSVL4I474NRT4amn\n4NBDQ0clhVbUiWBRE9DOYr6HiBTH3/wNzJoFr78OJ53k5wuMHh06KimkbEcBZfbQtgJV0f1KYFch\nAmmfCKYJYSLx8s//DNde6xeRu/vu0NGkV/vkr8yffGU7Cmi5mU2K7tcCdWbW4pybDawws/V5BaFR\nQCKxt307jB8Py5bBCSeEjkagNKOAGoG69rH8ZrYuOl8PtOZ78ReR8lBTA3fdBdOmQWtr6GikELIZ\nBbTUzAaZWUvGuRYzW5l5Ll9q+hGJv6lT4TOfgTPPhA0bQkeTXloLSESC+POf4dvfhptvhmefhSOP\nDB1Remk/ABEJ4sor/Wzhhx+GIUNCR5NOSgAiEsRbb0FzMzzzjJ8zUFXV83OksBKzGqj6AETKy/77\nw7x5fn/h884LHU26qA9ARGLh9dd9E9Dy5ZooVmqJqQGISHnq1w9uuQUmTYLnngsdjfSGEoCI5G3m\nTJg/388WXrgwdDSSLTUBiUjBbNgAn/yknzA2ZUroaJJPo4BEJFb+8z/9ZLFt2+CAA0JHk2yJ6QPQ\nKCCRZBg/HiZMgKuvDh1JcmkUkIjE1ssvw8iRsGOH31hGiiMxNQARSY7DD/dbSp54IqxYEToa6Ypq\nACJSFGZ+hvCFF8LmzTB4cOiIkkedwCISa5deCq+8Aj/4AVRUhI4mWdQEJCKx9uUvwx//6GsCv/pV\n6GgkkxKAiBTVQQfB4sVw7LFwyil+ZzGJBzUBiUjJzJsHv/gFPP44FGAUY+qpD0BEysY77/jhoYsX\nw9ixoaMpf+oDEJGysd9+MHkyPPZY6EgEYpQANBNYJB3q62HNmtBRlDfNBBaRsrRxI5x/vkYEFYKa\ngESkrNTUwKuvwksvhY5Eip4AnHNNzrlTnHNjiv1eIhJ//fvD1Kl+lrCElVUTkHNuvpldl3HcCOwB\nasxsUTfPawJWmNnOHl5fTUAiKbJ5s18naPFiOPXU0NGUr6I3AUUX8caM41rAzGxldNzdN/s64Djn\nXGP0PBERjj4a7rsPbrwxdCTp1mMCiL7hZ87dm47/9k90vgF8rcA5NzXjtgJoBR4HngfOLmjkIlLW\nTj7Z1wR27w4dSXr1zfJxmVWMSiDzIxsEYGZLP/Ak524DTgUM+HaOMYpIAg0YAKefDt/5DsyaFTqa\ndMo2AeTEzNqADyQGERGA2bPh7LN9TWDRIi0PUWrZjgLK7KFtBaqi+5XArkIE0j4RTBPCRNJj7Fh4\n4QX47/+Gn/0sdDTx1j75K/MnX9mOAlpuZpOi+7VAnZm1OOdm40f5rM8rCI0CEkm1WbOgXz9obg4d\nSXkpxSigRqDOOTcDwMzWRefrgdZ8L/4iIhddBHfd5ReLk9LJZhTQUjMbZGYtGedazGxl5rl8qelH\nJL2OOcbftrWFjaNcaC0gEUmUj3wEnnwSjjgidCTlQ2sBiUgiVFXBroIMKZFsKQGISCwMHQq/+U3o\nKNIlNglAfQAi6XbCCbB2begoyoP6AEQkUXbuhI99DHbs8LOEpWfqAxCRRBg8GMaNg//4j9CRpIcS\ngIjExsEHwxtvhI4iPZQARCQ29tkH3nsvdBTpoQQgIrHRt68SQCnFJgFoFJCIHHIIrF4NGhPSPY0C\nEpHEeeMNmDgRpkyBuXNDRxN/+Y4CKup+ACIivXHggfCTn/jRQEOHwjnnhI4o2ZQARCRWDjsMHn0U\nGhpg4EA488zQESVXbPoARETajRoFjzzil4lesyZ0NMmlBCAisXT88fDQQ37LyOeeCx1NMqkTWERi\n7b77YPFiWLkydCTxk28nsBKAiMTau+9CTY3vHD7uuNDRxIvWAhKRRNt3X7j6aliwIHQkyRObBKCJ\nYCLSlaYmeOwxePrp0JHEgyaCiUiqPPggXHON3zdg3jwYPTp0ROGpCUhEUuGcc2DbNvjEJ2DSJJg2\nDX7969BRlbeiJgDnXKNzbolz7h7n3KxivpeIJN+BB8K11/pEMG6cnyw2fTps2hQ6svKUVQJwzs3v\ncNzonKt3zjX18NTnzOxsYAlwb44xioj8lX79YNYs2LoV6urg5JPh3HPhxRdDR1ZeekwA0UW+MeO4\nFjAzWxkdj+nquWa2s/1pZtaWX6giIn+tf3+YM8fXCI49FiZMgPPP1+by2eoxAZjZImB7xqnpwJ7o\n/nagAd6vFUzNuB3Yfh7YVdiwRUT26t8frrvOJ4KRI+HEE+GHPwwdVfxluxhcZi9zJbA743gQgJkt\n7eK51cCK3ocmItI7AwbADTf4ZSSuucbXBgowWjKxij4KyMwWqPlHRErp5JP93gKaN9C9bBNA5iD9\nVqAqul+JmndEJGb69IGZM+FeDT3pVrYJILMStQSoie7XAI8XIpD2mcCaESwihXDRRbBsGezZ0+ND\ny0L77N/Mn3z1OBM46sS9F/iimbVE52YAO4Dq9nN5BaGZwCJSBNOnw0knwRVXhI6kOLQaqIhIF1at\n8gvJbdiQzM7gxCwFoaYfESm0iRPhzTfhqadCR1JYWgxORCQLX/2qXyriu98NHUnhqQlIRKQbr74K\nw4bBzp1QWRk6msJKTBOQiEgxHHIIfP7zsGVL6EjiJzYJQH0AIlIsX/86jB0bOorCUR+AiEjKqQlI\nRERyogQgIpJSSgAiIimlBCAiklKxSQAaBSQikh2NAhIRSTmNAhIRkZwoAYiIpJQSgIhISikBiIik\nlBKAiEhKKQGIiKSUEoCISErFJgFoIpiISHY0EUxEJOU0EUxERHLSt5gv7pyrAGqADwHbzWxnMd9P\nRESyl1UNwDk3v8Nxo3Ou3jnX1MNTPwY0AK1AwrZjFhEpbz0mgOgi35hxXAuYma2Mjsd08/RngSHA\nvcD2/EItX0nv2Fb5yluSy5fkshVCVp3AzrnHzOy06P58YLmZrXLO1QO1ZrbAOdcIGOCi25XA2Wa2\nKGoKmmlmX+3i9RPdCRx11IQOo2hUvvKW5PIluWyQfydwtn0AmW9QCezOOB4EYGZLOwlum3PuFHwT\n0IpcgxQRkcIr6iggM1sV/awzs/XFfK9sq3rdPa6z32VzLvO4q/v5ClW+rspa6Kp1qcoX4rPL9vV6\nW7bOzifpb7Oz80kqXxyuLbk0Ad0GrIiagBqBajNbkFcQBWgCyraq193jOvtdNucyjzu7X4hqaKjy\ndVXW7h6Ti1KVr7efXW9iyzXubB7T1e/iUL5ifXadnU/T/72Ox92Ur6RNQEuAOmAVfohnQZp2CjKr\nLcvX6O5xnf0um3OZx53dL+fydVXW7h6Ti1KVr7efXW9i6042r9HbsnV2PkT5ivXZdXY+Tf/3Oh4X\n+m+yxwQQfcuvc87NMLMWM1vnnKuLOoBbC9G0k08GExGR3MRiKQgRESk9LQUhIpJSsUoAzrnqqGkJ\n51yF87ONpzo/j6DsZZavs+Ny1+Hzq44+v1nOuerQsRVCF3+fs51zA0PHVgid/T065+4JFU8hdfK3\nucQ5NyN0XIXSybWlyTl3iut+om7pEoDLbjmJaUD7xf76aLbxSmBmicLMWQ7l6+w4tnIoXy3wDP7z\nayTmcihfHb58e/CDIWItl79PF836L1GIOcuhbAbMMLOWUsWYj96WLzq/IhqC320fbUkSgMt+OYnH\nM55WiX/Qa8T8P1iO5YMymRyXS/nMbJmZteHXgnq4hOH2Wo7lW4UfHVdR7Dku+cqlfFGtbU/0E1s5\nfnY7gUHRt+RYfwHL8dpSBxwXJYra7l6/JAnAzBbx12sBTWfvH9Z2/EWio1bn3MDoA9pW5BDz0svy\nuQ73Yz8CKtfyRVXSFXFfBTaXv0/nXFP05WSdc25W8aPMXY6fXzX+S9gQ59zgIoeYs1zK5pxrNLMd\n+LXKelrQMqhcr534hPA8cHZ3r1/KPoAel5PAF2Zs1Kb6beBUoB6/mFzcZVu+j2W0GXc8jrNelS+6\n+M8BLnXOTS1RjPno7d/nM1EZq4l5DSfSq88vquFspzyaKHv7f++56LOrI1mfXfvf5m34a2ct/jra\npaLuB9BbHRaLawN2BgqlKDouhtfV4njlqkN52vtvEqND+WLd7JOLTv4+XwNOCxROQaXt2gJ8YG22\nzpSyBpDZmdQKVEX3K4FdJYyjWFS+8qbyla8klw2KWL5QTUBL2NuxW8MHO0fLkcpX3lS+8pXkskER\ny1eqUUDvLycBYGbrovMFW04iJJVP5YuzJJcvyWWD4pdPS0GIiKRUrGYCi4hI6SgBiIiklBKAiEhK\nKQGIiKSUEoCISEopAYiIpJQSgIhISikBiIik1P8DFb7T8hHyhSIAAAAASUVORK5CYII=\n",
+       "text": [
+        "<matplotlib.figure.Figure at 0x11c9bc110>"
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    }
+   ],
+   "metadata": {}
+  }
+ ]
 }

--- a/halotools/empirical_models/abundance_matching/abundance_matching.py
+++ b/halotools/empirical_models/abundance_matching/abundance_matching.py
@@ -77,8 +77,8 @@ class AbundanceMatching(PrimGalpropModel):
                             type = 'cumulative', 
                             n_increases_with_x = False)
                         )
-        else:
-            self.halo_abundance_function = halo_abundance_function
+        
+        self.halo_abundance_function = halo_abundance_function
 
 
         new_method_name = 'mean_' + galprop_name
@@ -112,7 +112,7 @@ class AbundanceMatching(PrimGalpropModel):
 
         return func(halo_mass)
 
-    def match(self,n1, n2, x1, x2):
+    def match(self, n1, n2, x1, x2):
         """
         Given two cumulative abundnace functions, n1 and n2, return x1(x2).
         e.g. return the stellar mass halo mass relation given the stellar 
@@ -142,11 +142,11 @@ class AbundanceMatching(PrimGalpropModel):
         x2 = np.sort(x2)
         
         #calculate abundances for x1
-        n = n1(x1)
+        n = n1.n(x1)
         
         #invert the secondary abundance function at each x2
-        sort_inds = np.argsort(n2(x2))
-        inverted_n2 = interp1d(n2(x2)[sort_inds],x2[sort_inds])
+        sort_inds = np.argsort(n2.n(x2))
+        inverted_n2 = interp1d(n2.n(x2)[sort_inds],x2[sort_inds])
         
         #calculate the value of x2 at the abundances of x1
         x2n = inverted_n2(n)

--- a/halotools/empirical_models/smhm_models/scatter_models.py
+++ b/halotools/empirical_models/smhm_models/scatter_models.py
@@ -285,8 +285,11 @@ class ConstantLogNormalScatter(ScatterModelTemplate):
         scatter_scale = np.zeros(num_gals) + self.param_dict['scatter_model_param1']
 
         np.random.seed(seed=seed)
+
+        # Only draw from a Gaussian for cases with non-zero scatter
+        result = np.where(scatter_scale > 0, np.random.normal(loc=0, scale=scatter_scale), 0)
             
-        return np.random.normal(loc=0, scale=scatter_scale)
+        return result
 
 
         


### PR DESCRIPTION
Fixed bug in the call to AbundanceMatching.match - an AbundanceFunction class is not a callable; instead, within match the method AbundanceFunction.n is called.

Fixed notebook so that the AbundanceMatching class properly instantiates. Within the notebook, AbundanceMatching.mean_mstar(prim_haloprop=[1e12, 1e13]) now works. However, there is a new error I don't understand yet about the interpolation range. 
