### PR TITLE
fix to test failure for Leauthaud11Cens

### DIFF
--- a/halotools/empirical_models/occupation_models/leauthaud11_components.py
+++ b/halotools/empirical_models/occupation_models/leauthaud11_components.py
@@ -261,7 +261,6 @@ class Leauthaud11Sats(OccupationComponent):
 
         self.central_occupation_model = cenocc_model
 
-
         super(Leauthaud11Sats, self).__init__(
             gal_type='satellites', threshold=threshold,
             upper_occupation_bound=float("inf"),

--- a/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
+++ b/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
@@ -16,28 +16,29 @@ def test_Leauthaud11Cens():
     # Verify that the mean and Monte Carlo occupations are both reasonable and in agreement
     # for halos of mass 1e12
     model = Leauthaud11Cens()
-    ncen1 = model.mean_occupation(prim_haloprop=1.e12)
-    mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4))*1e12, seed=43)
-    #assert 0.5590 < np.mean(mcocc) < 0.5592
+    ncen1 = model.mean_occupation(prim_haloprop=5e11)
+    mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4))*5e11, seed=43)
 
     # Check that the model behavior is altered in the expected way by changing param_dict values
+
+    # Increasing scatter picks up more galaxies in low-mass halos
     model.param_dict['scatter_model_param1'] *= 1.5
-    ncen2 = model.mean_occupation(prim_haloprop=1.e12)
-    assert ncen2 < ncen1
+    ncen2 = model.mean_occupation(prim_haloprop=5e11)
+    assert ncen2 > ncen1
 #
     model.param_dict['smhm_m1_0'] *= 1.1
-    ncen3 = model.mean_occupation(prim_haloprop=1.e12)
+    ncen3 = model.mean_occupation(prim_haloprop=5e11)
     assert ncen3 < ncen2
 #
     model.param_dict['smhm_m1_a'] *= 1.1
-    ncen4 = model.mean_occupation(prim_haloprop=1.e12)
+    ncen4 = model.mean_occupation(prim_haloprop=5e11)
     assert ncen4 == ncen3
 
     # Check that increasing stellar mass thresholds decreases the mean occupation
     model2 = Leauthaud11Cens(threshold=10.75)
-    ncen5 = model2.mean_occupation(prim_haloprop=1.e12)
+    ncen5 = model2.mean_occupation(prim_haloprop=5e11)
     model3 = Leauthaud11Cens(threshold=11.25)
-    ncen6 = model3.mean_occupation(prim_haloprop=1.e12)
+    ncen6 = model3.mean_occupation(prim_haloprop=5e11)
     assert ncen6 < ncen5 < ncen1
 
 
@@ -51,7 +52,6 @@ def test_Leauthaud11Sats():
     model = Leauthaud11Sats()
     nsat1 = model.mean_occupation(prim_haloprop=5.e12)
     mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4))*5e12, seed=43)
-    #assert 0.391 < np.mean(mcocc) < 0.392
 
     # Check that the model behavior is altered in the expected way by changing param_dict values
     model.param_dict['alphasat'] *= 1.1

--- a/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
+++ b/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
@@ -57,22 +57,44 @@ def test_Leauthaud11Sats():
     model.param_dict['alphasat'] *= 1.1
     nsat2 = model.mean_occupation(prim_haloprop=5.e12)
     assert nsat2 < nsat1
-#
+
+    # Msat := Bsat(mhalo_thresh/1e12)**betasat
+    # since mhalo_thresh(logM*=10.5) > 1e12, increasing betasat should increase Msat
+    msat1 = np.copy(model._msat)
     model.param_dict['betasat'] *= 1.1
-    nsat3 = model.mean_occupation(prim_haloprop=5.e12)
-    assert nsat3 > nsat2
-#
-    model.param_dict['betacut'] *= 1.1
-    nsat4 = model.mean_occupation(prim_haloprop=5.e12)
-    assert nsat4 < nsat3
-#
-    model.param_dict['bcut'] *= 1.1
-    nsat5 = model.mean_occupation(prim_haloprop=5.e12)
-    assert nsat5 < nsat4
-#
+    model._update_satellite_params()
+    msat2 = np.copy(model._msat)
+    assert msat2 > msat1
+
+    # Msat := Bsat(mhalo_thresh/1e12)**betasat
+    # Increasing Bsat should increase Msat regardless of mass
+    model._update_satellite_params()
+    msat1 = np.copy(model._msat)
     model.param_dict['bsat'] *= 1.1
-    nsat6 = model.mean_occupation(prim_haloprop=5.e12)
-    assert nsat6 < nsat5
+    model._update_satellite_params()
+    msat2 = np.copy(model._msat)
+    assert msat2 > msat1
+#
+    # Mcut := Bcut(mhalo_thresh/1e12)**betacut
+    # Default value of betacut is -0.13 for default threshold of 10.5
+    # since mhalo_thresh(logM*=10.5) > 1e12, increasing betacut should increase Mcut
+    model.param_dict['betacut'] = -0.13
+    model._update_satellite_params()
+    mcut1 = np.copy(model._mcut)
+    model.param_dict['betacut'] = -0.1
+    model._update_satellite_params()
+    mcut2 = np.copy(model._mcut)
+    assert mcut2 > mcut1
+# #
+    # Mcut := Bcut(mhalo_thresh/1e12)**betacut
+    # Increasing Bcut should increase Mcut regardless of mass
+    model._update_satellite_params()
+    mcut1 = np.copy(model._mcut)
+    model.param_dict['bcut'] *= 1.1
+    model._update_satellite_params()
+    mcut2 = np.copy(model._mcut)
+    assert mcut2 > mcut1
+# #
 #
     # Check that modulate_with_cenocc strictly decreases the mean occupations
     model2a = Leauthaud11Sats(modulate_with_cenocc=False)


### PR DESCRIPTION
This resolves one of the two remaining failures. One of the failing tests was simply poorly written as the halo mass it used to test the model was close to a pivot point where the effect of increasing scatter on ncen turned over. 

The remaining nsat test is more subtle. Patch coming soon
